### PR TITLE
Add configure_flags support and FFmpeg scan config

### DIFF
--- a/harness-ffmpeg.yaml.example
+++ b/harness-ffmpeg.yaml.example
@@ -1,0 +1,56 @@
+# FFmpeg vulnerability scan configuration
+# Target: FFmpeg 4.4 (known-vulnerable release for pipeline validation)
+
+# Target
+repo_url: https://github.com/FFmpeg/FFmpeg
+repo_commit: n4.4
+binary_name: ffmpeg
+project_name: FFmpeg
+project_description: "A multimedia framework for decoding, encoding, transcoding, muxing, demuxing, streaming, filtering, and playing audio and video. Handles dozens of codecs and container formats (H.264, HEVC, VP9, AAC, MP3, MKV, MP4, AVI, etc.)."
+
+# Build — FFmpeg uses custom ./configure, not autotools.
+# It ignores CFLAGS/LDFLAGS env vars; must use --extra-cflags/--extra-ldflags.
+configure_flags: >-
+  --cc=clang
+  --extra-cflags="-fsanitize=address -g -O1 -fno-omit-frame-pointer"
+  --extra-ldflags="-fsanitize=address"
+  --disable-x86asm
+  --disable-doc
+  --disable-ffplay
+  --disable-network
+  --disable-shared
+
+# Scan scope — FFmpeg has ~2000 C files; focus on highest-risk
+exclude_patterns:
+  - "*/tests/*"
+  - "*/test/*"
+  - "*/doc/*"
+  - "*/tools/*"
+  - "*/compat/*"
+  - "*_template.c"
+max_files_to_scan: 20  # start small, increase after validation
+
+# Agent
+ranking_model: anthropic/claude-sonnet-4-6
+worker_model: anthropic/claude-sonnet-4-6
+validation_model: anthropic/claude-sonnet-4-6
+max_turns_per_worker: 30
+
+# Parallelism — keep low for first run
+max_parallel_workers: 4
+
+# Spend limits
+max_run_spend_usd: 50.0
+max_day_spend_usd: 100.0
+
+# Container — FFmpeg compilation is heavy; increase resources
+worker_image: vuln-harness-worker:latest
+container_timeout_seconds: 2400  # 40 min (FFmpeg compile takes ~10-15 min)
+worker_memory_gb: 6
+worker_cpus: 4
+
+# Storage
+redis_url: redis://localhost:6379
+postgres_url: postgresql://harness:changeme@localhost:5432/vulnharness
+run_output_dir: ./runs
+findings_encryption_key_env: FINDINGS_ENC_KEY

--- a/harness.yaml.example
+++ b/harness.yaml.example
@@ -5,6 +5,11 @@ binary_name: parser
 project_name: libfoo
 project_description: "A C library for parsing FooBar format files"
 
+# Build — optional flags for ./configure (empty = default --disable-shared)
+# Use this for projects with non-standard configure scripts (e.g. FFmpeg)
+# configure_flags: "--extra-cflags='-fsanitize=address' --disable-x86asm"
+configure_flags: ""
+
 # Scan scope
 exclude_patterns:
   - "*/test/*"

--- a/harness/config.py
+++ b/harness/config.py
@@ -47,6 +47,9 @@ class Config(BaseSettings):
     project_name: str
     project_description: str
 
+    # Build
+    configure_flags: str = ""  # extra flags for ./configure (e.g. FFmpeg's --extra-cflags)
+
     # Scan scope
     exclude_patterns: list[str] = []
     max_files_to_scan: int | None = None

--- a/harness/dispatcher.py
+++ b/harness/dispatcher.py
@@ -49,6 +49,7 @@ async def _run_container(
         "-e", f"PROJECT_NAME={config.project_name}",
         "-e", f"PROJECT_DESCRIPTION={config.project_description}",
         "-e", f"BINARY_NAME={config.binary_name}",
+        "-e", f"CONFIGURE_FLAGS={config.configure_flags}",
         "-e", "ASAN_OPTIONS=detect_leaks=1:abort_on_error=1:print_stacktrace=1",
         "--security-opt", "no-new-privileges",
         "--cap-drop", "ALL",

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -15,6 +15,7 @@ RUN echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/99no-check-
     automake \
     libtool \
     pkg-config \
+    nasm \
     git \
     python3 \
     python3-pip \

--- a/worker/entrypoint.sh
+++ b/worker/entrypoint.sh
@@ -35,13 +35,20 @@ emit_build_failure() {
     exit 1
 }
 
+# Build configure command: use CONFIGURE_FLAGS if provided, else default --disable-shared
+if [ -n "${CONFIGURE_FLAGS:-}" ]; then
+    CONF_CMD="./configure $CONFIGURE_FLAGS"
+else
+    CONF_CMD="./configure --disable-shared"
+fi
+
 # Try autotools first (configure or configure.ac)
 if [ -f ./configure ]; then
-    echo "Build system: autotools (configure)" >&2
-    BUILD_OUTPUT=$(./configure --disable-shared 2>&1 && make -j"$(nproc)" 2>&1) || emit_build_failure "$BUILD_OUTPUT"
+    echo "Build system: configure (flags: ${CONFIGURE_FLAGS:---disable-shared})" >&2
+    BUILD_OUTPUT=$(eval "$CONF_CMD" 2>&1 && make -j"$(nproc)" 2>&1) || emit_build_failure "$BUILD_OUTPUT"
 elif [ -f ./configure.ac ] || [ -f ./configure.in ]; then
     echo "Build system: autotools (needs autoreconf)" >&2
-    BUILD_OUTPUT=$(autoreconf -fi 2>&1 && ./configure --disable-shared 2>&1 && make -j"$(nproc)" 2>&1) || emit_build_failure "$BUILD_OUTPUT"
+    BUILD_OUTPUT=$(autoreconf -fi 2>&1 && eval "$CONF_CMD" 2>&1 && make -j"$(nproc)" 2>&1) || emit_build_failure "$BUILD_OUTPUT"
 elif [ -f CMakeLists.txt ]; then
     echo "Build system: cmake" >&2
     mkdir -p build && cd build


### PR DESCRIPTION
## Summary
- Add `configure_flags` config field for projects with non-standard build systems (FFmpeg uses `--extra-cflags` instead of `CFLAGS`)
- Flags passed through as `CONFIGURE_FLAGS` env var to worker containers
- Add `nasm` to worker Dockerfile for x86 assembly codec support
- Add FFmpeg 4.4 example config targeting top 20 files with $50 budget

## FFmpeg config highlights
- **Version**: `n4.4` (known-vulnerable, validates pipeline)
- **Build**: `--extra-cflags="-fsanitize=address ..."`, `--disable-x86asm`, `--disable-ffplay`, `--disable-network`
- **Scope**: 20 highest-risk files out of ~2000, ranked by sonnet
- **Resources**: 6GB RAM, 4 CPUs, 40 min timeout (FFmpeg compile takes ~10-15 min)

## Test plan
- [ ] Existing harness.yaml configs still work (empty configure_flags = default `--disable-shared`)
- [ ] `cp harness-ffmpeg.yaml.example harness-ffmpeg.yaml && HARNESS_CONFIG=harness-ffmpeg.yaml python -m harness.cli run`
- [ ] Worker container compiles FFmpeg 4.4 with ASAN successfully
- [ ] Agent receives compiled `ffmpeg` binary in PATH and can test it

🤖 Generated with [Claude Code](https://claude.com/claude-code)