### PR TITLE
Add static file ranker and pre-compilation build step

### DIFF
--- a/harness-ffmpeg.yaml.example
+++ b/harness-ffmpeg.yaml.example
@@ -14,11 +14,14 @@ configure_flags: >-
   --cc=clang
   --extra-cflags="-fsanitize=address -g -O1 -fno-omit-frame-pointer"
   --extra-ldflags="-fsanitize=address"
-  --disable-x86asm
+  --disable-asm
   --disable-doc
   --disable-ffplay
   --disable-network
   --disable-shared
+
+# Ranking — static analysis reads actual code, free and instant
+ranking_strategy: static
 
 # Scan scope — FFmpeg has ~2000 C files; focus on highest-risk
 exclude_patterns:

--- a/harness.yaml.example
+++ b/harness.yaml.example
@@ -19,6 +19,9 @@ exclude_patterns:
   - "*/third_party/*"
 max_files_to_scan: 100
 
+# Ranking strategy: "static" (regex-based, free, instant) | "llm" (LLM-based, ~$0.07/batch)
+ranking_strategy: static
+
 # Agent — model strings use litellm format: "provider/model"
 # Examples: anthropic/claude-opus-4-6, openai/gpt-4o, ollama/llama3
 ranking_model: anthropic/claude-opus-4-6

--- a/harness/cli.py
+++ b/harness/cli.py
@@ -54,6 +54,7 @@ def rank(config_path: str):
         ranking_model=cfg.ranking_model,
         max_files_to_scan=cfg.max_files_to_scan,
         audit=audit,
+        strategy=cfg.ranking_strategy,
     ))
 
     write_rankings_json(
@@ -78,9 +79,130 @@ def rank(config_path: str):
     click.echo(f"Run ID: {run_id}")
 
 
+def _clone_repo(cfg, run_dir: Path) -> Path:
+    """Clone or resolve repo path. Returns local path."""
+    repo_path = Path(cfg.repo_url) if Path(cfg.repo_url).exists() else None
+    if repo_path is None:
+        import subprocess
+        repo_path = run_dir / "repo"
+        if not repo_path.exists():
+            click.echo(f"Cloning {cfg.repo_url} ...")
+            subprocess.run(
+                ["git", "clone", "--depth", "1", "--branch", cfg.repo_commit, cfg.repo_url, str(repo_path)],
+                check=True,
+            )
+    return repo_path
+
+
 @cli.command()
 @click.option("--config", "config_path", default="./harness.yaml", help="Path to harness.yaml")
-def run(config_path: str):
+def build(config_path: str):
+    """Compile target with ASAN in a single container. Saves binaries for worker reuse."""
+    os.environ.setdefault("HARNESS_CONFIG", config_path)
+    from harness.config import Config
+
+    cfg = Config()
+    run_id = str(uuid.uuid4())
+    run_dir = cfg.run_output_dir / run_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+    bin_dir = run_dir / "bin"
+    bin_dir.mkdir(exist_ok=True)
+
+    repo_path = _clone_repo(cfg, run_dir)
+    repo_real = os.path.realpath(str(repo_path))
+    bin_real = os.path.realpath(str(bin_dir))
+
+    click.echo(f"Building {cfg.project_name} with ASAN...")
+
+    # Run a build-only container: compile, collect binaries to /output
+    cmd = [
+        "docker", "run", "--rm",
+        "--name", f"builder-{run_id[:12]}",
+        "--memory", f"{cfg.worker_memory_gb}g",
+        "--cpus", str(cfg.worker_cpus),
+        "--tmpfs", "/tmp:size=4g",
+        "-v", f"{repo_real}:/target/src:ro",
+        "-v", f"{bin_real}:/output",
+        "-e", f"BINARY_NAME={cfg.binary_name}",
+        "-e", f"CONFIGURE_FLAGS={cfg.configure_flags}",
+        "--entrypoint", "/bin/bash",
+        cfg.worker_image,
+        "-c", _BUILD_SCRIPT,
+    ]
+
+    import subprocess
+    result = subprocess.run(cmd, capture_output=True, text=True)
+
+    if result.returncode != 0:
+        click.echo(f"Build failed (exit {result.returncode}):")
+        click.echo(result.stderr[-2000:] if len(result.stderr) > 2000 else result.stderr)
+        raise SystemExit(1)
+
+    # List collected binaries
+    binaries = list(bin_dir.iterdir())
+    click.echo(f"Build complete. {len(binaries)} binaries collected:")
+    for b in sorted(binaries):
+        size_mb = b.stat().st_size / (1024 * 1024)
+        click.echo(f"  {b.name} ({size_mb:.1f} MB)")
+    click.echo(f"\nBin dir: {bin_dir}")
+    click.echo(f"Run ID: {run_id}")
+    click.echo(f"\nTo scan: vuln-harness run --config {config_path} --bin-dir {bin_dir}")
+
+
+# Build script executed inside the builder container
+_BUILD_SCRIPT = r"""
+set -euo pipefail
+
+cp -a /target/src /tmp/src
+cd /tmp/src
+git submodule update --init --recursive 2>/dev/null || true
+
+export CC=clang
+export CFLAGS="-fsanitize=address -g -O1 -fno-omit-frame-pointer -fPIC"
+export LDFLAGS="-fsanitize=address"
+
+if [ -n "${CONFIGURE_FLAGS:-}" ]; then
+    CONF_CMD="./configure $CONFIGURE_FLAGS"
+else
+    CONF_CMD="./configure --disable-shared"
+fi
+
+if [ -f ./configure ]; then
+    echo "Build system: configure" >&2
+    eval "$CONF_CMD" >&2 && make -j"$(nproc)" >&2
+elif [ -f ./configure.ac ] || [ -f ./configure.in ]; then
+    echo "Build system: autotools" >&2
+    autoreconf -fi >&2 && eval "$CONF_CMD" >&2 && make -j"$(nproc)" >&2
+elif [ -f CMakeLists.txt ]; then
+    echo "Build system: cmake" >&2
+    mkdir -p build && cd build
+    cmake -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ \
+        -DCMAKE_C_FLAGS="$CFLAGS" -DCMAKE_CXX_FLAGS="$CFLAGS" \
+        -DCMAKE_EXE_LINKER_FLAGS="$LDFLAGS" -DCMAKE_SHARED_LINKER_FLAGS="$LDFLAGS" \
+        -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=OFF .. >&2
+    make -j"$(nproc)" >&2
+    cd ..
+elif [ -f Makefile ] || [ -f makefile ] || [ -f GNUmakefile ]; then
+    echo "Build system: Makefile" >&2
+    make CC=clang CFLAGS="$CFLAGS" LDFLAGS="$LDFLAGS" -j"$(nproc)" >&2 || true
+fi
+
+# Collect binaries to /output (mounted from host)
+find /tmp/src -type f -executable \
+    ! -name '*.sh' ! -name '*.py' ! -name '*.pl' ! -name '*.cmake' \
+    ! -name '*.sample' ! -name '*.so*' ! -name '*.o' \
+    ! -path '*/CMakeFiles/*' ! -path '*/.git/*' \
+    -exec cp -n {} /output/ \; 2>/dev/null || true
+
+echo "=== collected binaries ===" >&2
+ls /output/ >&2
+"""
+
+
+@cli.command()
+@click.option("--config", "config_path", default="./harness.yaml", help="Path to harness.yaml")
+@click.option("--bin-dir", "bin_dir", default=None, help="Pre-compiled binaries dir (from 'build' command)")
+def run(config_path: str, bin_dir: str | None):
     """Full pipeline: rank, dispatch workers, parse, validate, report."""
     os.environ.setdefault("HARNESS_CONFIG", config_path)
     from harness.config import Config
@@ -93,18 +215,10 @@ def run(config_path: str):
 
     audit = AuditLog(run_dir / "audit.jsonl")
     audit.write(run_id=run_id, event_type="run_start", actor="orchestrator",
-                payload={"command": "run", "config": config_path})
+                payload={"command": "run", "config": config_path, "bin_dir": bin_dir})
 
     # Step 1: Clone or use local repo
-    repo_path = Path(cfg.repo_url) if Path(cfg.repo_url).exists() else None
-    if repo_path is None:
-        import subprocess
-        repo_path = run_dir / "repo"
-        click.echo(f"Cloning {cfg.repo_url} ...")
-        subprocess.run(
-            ["git", "clone", "--depth", "1", "--branch", cfg.repo_commit, cfg.repo_url, str(repo_path)],
-            check=True,
-        )
+    repo_path = _clone_repo(cfg, run_dir)
 
     # Step 2: Rank files
     click.echo("Stage 1: Ranking files...")
@@ -116,6 +230,7 @@ def run(config_path: str):
         ranking_model=cfg.ranking_model,
         max_files_to_scan=cfg.max_files_to_scan,
         audit=audit,
+        strategy=cfg.ranking_strategy,
     ))
     write_rankings_json(
         run_dir=run_dir, run_id=run_id, repo_url=cfg.repo_url,
@@ -131,9 +246,12 @@ def run(config_path: str):
     click.echo(f"  Enqueued {len(ranked)} jobs")
 
     # Step 4: Dispatch workers
-    click.echo("Stage 3: Dispatching workers...")
+    if bin_dir:
+        click.echo(f"Stage 3: Dispatching workers (pre-compiled: {bin_dir})...")
+    else:
+        click.echo("Stage 3: Dispatching workers (compiling per container)...")
     from harness.dispatcher import dispatch_run
-    results = asyncio.run(dispatch_run(run_id, cfg, audit))
+    results = asyncio.run(dispatch_run(run_id, cfg, audit, repo_path=repo_path, bin_path=bin_dir))
     click.echo(f"  Completed {len(results)} containers")
 
     # Step 5: Parse and validate

--- a/harness/config.py
+++ b/harness/config.py
@@ -50,6 +50,9 @@ class Config(BaseSettings):
     # Build
     configure_flags: str = ""  # extra flags for ./configure (e.g. FFmpeg's --extra-cflags)
 
+    # Ranking strategy: "static" (regex-based, free, instant) | "llm" (LLM-based)
+    ranking_strategy: str = "static"
+
     # Scan scope
     exclude_patterns: list[str] = []
     max_files_to_scan: int | None = None

--- a/harness/dispatcher.py
+++ b/harness/dispatcher.py
@@ -21,6 +21,7 @@ async def _run_container(
     config,
     audit: AuditLog,
     repo_path: str | None = None,
+    bin_path: str | None = None,
 ) -> tuple[str, str, str, int]:
     """Launch a single worker container. Returns (job_id, stdout, stderr, exit_code)."""
     import os
@@ -37,6 +38,10 @@ async def _run_container(
         "--tmpfs", "/tmp:size=4g",
         "-v", f"{repo}:/target/src:ro",
     ]
+    # Mount pre-compiled binaries if available (skips compilation in entrypoint)
+    if bin_path:
+        bin_real = os.path.realpath(bin_path)
+        cmd.extend(["-v", f"{bin_real}:/target/bin:ro"])
     # Pass through provider API keys from environment (litellm reads them automatically)
     for key_name in ("ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GOOGLE_API_KEY"):
         key_val = os.environ.get(key_name)
@@ -179,6 +184,7 @@ async def dispatch_run(
     config,
     audit: AuditLog,
     repo_path: str | None = None,
+    bin_path: str | None = None,
 ) -> list[tuple[str, str, str, int]]:
     """Dispatch all queued jobs with concurrency control.
 
@@ -190,7 +196,7 @@ async def dispatch_run(
     async def worker(job):
         async with sem:
             result = await _run_container(
-                job.job_id, run_id, job.file_path, config, audit, repo_path,
+                job.job_id, run_id, job.file_path, config, audit, repo_path, bin_path,
             )
             results.append(result)
 

--- a/harness/ranker.py
+++ b/harness/ranker.py
@@ -103,6 +103,40 @@ async def rank_files(
     ranking_model: str,
     max_files_to_scan: int | None,
     audit: AuditLog,
+    strategy: str = "static",
+) -> list[RankedFile]:
+    """Rank source files by vulnerability likelihood.
+
+    Routes to static analysis or LLM-based ranking based on strategy.
+    """
+    if strategy == "static":
+        from harness.static_ranker import rank_files_static
+
+        return await rank_files_static(
+            run_id=run_id,
+            repo_path=repo_path,
+            exclude_patterns=exclude_patterns,
+            max_files_to_scan=max_files_to_scan,
+            audit=audit,
+        )
+
+    return await _rank_files_llm(
+        run_id=run_id,
+        repo_path=repo_path,
+        exclude_patterns=exclude_patterns,
+        ranking_model=ranking_model,
+        max_files_to_scan=max_files_to_scan,
+        audit=audit,
+    )
+
+
+async def _rank_files_llm(
+    run_id: str,
+    repo_path: Path,
+    exclude_patterns: list[str],
+    ranking_model: str,
+    max_files_to_scan: int | None,
+    audit: AuditLog,
 ) -> list[RankedFile]:
     """Rank source files by vulnerability likelihood via litellm."""
     all_files = _enumerate_source_files(repo_path, exclude_patterns)
@@ -113,11 +147,14 @@ async def rank_files(
     all_ranked: list[RankedFile] = []
     total_cost = 0.0
 
-    batch_size = 200
+    batch_size = 100
     for i in range(0, len(all_files), batch_size):
         batch = all_files[i : i + batch_size]
         file_list = "\n".join(batch)
         prompt = _RANKING_PROMPT_TEMPLATE.format(file_list=file_list)
+
+        # Each file entry in the JSON response needs ~30-40 tokens
+        response_tokens = max(4096, len(batch) * 50)
 
         last_exc = None
         for attempt in range(3):
@@ -125,7 +162,7 @@ async def rank_files(
                 response = await call_llm(
                     prompt=prompt,
                     model=ranking_model,
-                    max_tokens=4096,
+                    max_tokens=response_tokens,
                 )
                 break
             except Exception as e:

--- a/harness/static_ranker.py
+++ b/harness/static_ranker.py
@@ -1,0 +1,270 @@
+"""Stage 1 alternative: static analysis file ranker.
+
+Scores files by counting vulnerability-relevant patterns (unsafe calls,
+input sources, memory management, pointer arithmetic) in actual source code.
+Runs in ~2-3 seconds on 3000+ files. No LLM, no API cost.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from harness.audit import AuditLog
+from harness.ranker import RankedFile, _enumerate_source_files
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Compiled regex patterns (compiled once at module import)
+# ---------------------------------------------------------------------------
+
+_PATTERNS: dict[str, re.Pattern] = {
+    "unsafe_calls": re.compile(
+        r"\b(strcpy|strcat|sprintf|vsprintf|gets|scanf|sscanf|fscanf)\s*\("
+    ),
+    "input_sources": re.compile(
+        r"\b(fread|recv|recvfrom|fgets|getline|getenv)\s*\("
+    ),
+    "memory_mgmt": re.compile(
+        r"\b(malloc|calloc|realloc|free|mmap|munmap)\s*\("
+    ),
+    "pointer_arith": re.compile(
+        r"\*\s*\(\s*\w+\s*[+\-]|\w+\s*\[\s*[a-zA-Z_]\w*\s*[+\-\*]"
+    ),
+    "memcpy": re.compile(r"\bmemcpy\s*\("),
+}
+
+# Path fragments that indicate high-risk code
+_PATH_BONUS_PATTERNS = re.compile(
+    r"(parser|codec|format|demux|mux|decode|encode|compress|decompress|crypt|proto|net)"
+)
+# Path fragments that indicate low-risk code
+_PATH_PENALTY_PATTERNS = re.compile(
+    r"(^test/|/test/|^tests/|/tests/|^doc/|/doc/|^docs/|/docs/|"
+    r"^example/|/example/|^examples/|/examples/|^compat/|/compat/)"
+)
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FileSignals:
+    """Raw signal counts extracted from a single source file."""
+
+    path: str
+    loc: int = 0
+    unsafe_calls: int = 0
+    input_sources: int = 0
+    memory_mgmt: int = 0
+    pointer_arith: int = 0
+    memcpy_count: int = 0
+    path_bonus: float = 0.0
+    raw_score: float = field(default=0.0, init=False)
+
+
+# ---------------------------------------------------------------------------
+# Core scoring functions (pure, no I/O)
+# ---------------------------------------------------------------------------
+
+
+def _score_path_heuristic(rel_path: str) -> float:
+    """Return path-based bonus (+5) or penalty (-3) based on directory names."""
+    bonus = 0.0
+    if _PATH_BONUS_PATTERNS.search(rel_path.lower()):
+        bonus += 5.0
+    if _PATH_PENALTY_PATTERNS.search(rel_path.lower()):
+        bonus -= 3.0
+    return bonus
+
+
+def _extract_signals(rel_path: str, content: str) -> FileSignals:
+    """Extract all vulnerability signals from file content."""
+    signals = FileSignals(path=rel_path)
+    signals.loc = content.count("\n") + 1
+    signals.unsafe_calls = len(_PATTERNS["unsafe_calls"].findall(content))
+    signals.input_sources = len(_PATTERNS["input_sources"].findall(content))
+    signals.memory_mgmt = len(_PATTERNS["memory_mgmt"].findall(content))
+    signals.pointer_arith = len(_PATTERNS["pointer_arith"].findall(content))
+    signals.memcpy_count = len(_PATTERNS["memcpy"].findall(content))
+    signals.path_bonus = _score_path_heuristic(rel_path)
+    return signals
+
+
+def _compute_raw_score(signals: FileSignals) -> float:
+    """Apply weights and multipliers to produce a raw score."""
+    score = (
+        signals.unsafe_calls * 3.0
+        + signals.input_sources * 3.0
+        + signals.memory_mgmt * 2.0
+        + signals.pointer_arith * 2.0
+        + signals.memcpy_count * 2.0
+        + math.log2(signals.loc + 1) * 1.0
+        + signals.path_bonus
+    )
+
+    # Source+sink multiplier: file reads input AND does unsafe operations
+    if signals.input_sources > 0 and (signals.unsafe_calls > 0 or signals.memcpy_count > 0):
+        score *= 1.5
+
+    # Memory+pointer multiplier: manual memory AND pointer arithmetic
+    if signals.memory_mgmt > 0 and signals.pointer_arith > 0:
+        score *= 1.3
+
+    return score
+
+
+def _build_reason(signals: FileSignals) -> str:
+    """Build a human-readable reason string from signal counts."""
+    parts = []
+    if signals.unsafe_calls:
+        parts.append(f"{signals.unsafe_calls} unsafe calls")
+    if signals.input_sources:
+        parts.append(f"{signals.input_sources} input sources")
+    if signals.memcpy_count:
+        parts.append(f"{signals.memcpy_count} memcpy")
+    if signals.memory_mgmt:
+        parts.append(f"{signals.memory_mgmt} memory ops")
+    if signals.pointer_arith:
+        parts.append(f"{signals.pointer_arith} pointer arith")
+
+    # Note multipliers
+    has_source_sink = signals.input_sources > 0 and (
+        signals.unsafe_calls > 0 or signals.memcpy_count > 0
+    )
+    has_mem_ptr = signals.memory_mgmt > 0 and signals.pointer_arith > 0
+    if has_source_sink:
+        parts.append("source+sink boost")
+    if has_mem_ptr:
+        parts.append("mem+ptr boost")
+
+    parts.append(f"{signals.loc} LOC")
+
+    reason = ", ".join(parts)
+    return reason[:120]
+
+
+def _normalize_scores(signals_list: list[FileSignals]) -> list[RankedFile]:
+    """Normalize raw scores to 1-5 scale and produce RankedFile list."""
+    if not signals_list:
+        return []
+
+    min_raw = min(s.raw_score for s in signals_list)
+    max_raw = max(s.raw_score for s in signals_list)
+
+    results = []
+    for s in signals_list:
+        if max_raw == min_raw:
+            score = 3
+        else:
+            normalized = 1.0 + 4.0 * (s.raw_score - min_raw) / (max_raw - min_raw)
+            score = max(1, min(5, round(normalized)))
+
+        results.append(RankedFile(
+            path=s.path,
+            score=score,
+            reason=_build_reason(s),
+        ))
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# File I/O
+# ---------------------------------------------------------------------------
+
+_MAX_FILE_SIZE = 2 * 1024 * 1024  # 2 MB
+
+
+def _read_file_safe(file_path: Path) -> str | None:
+    """Read file content safely. Returns None for binary or unreadable files."""
+    try:
+        raw = file_path.read_bytes()
+    except (OSError, PermissionError):
+        return None
+
+    if len(raw) > _MAX_FILE_SIZE:
+        return None
+
+    # Binary detection: null bytes in first 8KB
+    if b"\x00" in raw[:8192]:
+        return None
+
+    try:
+        return raw.decode("utf-8")
+    except UnicodeDecodeError:
+        return raw.decode("latin-1")
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+async def rank_files_static(
+    run_id: str,
+    repo_path: Path,
+    exclude_patterns: list[str],
+    max_files_to_scan: int | None,
+    audit: AuditLog,
+) -> list[RankedFile]:
+    """Rank source files by static analysis signals.
+
+    Drop-in replacement for the LLM-based rank_files(). Reads actual file
+    content and scores based on vulnerability-relevant code patterns.
+    """
+    all_files = _enumerate_source_files(repo_path, exclude_patterns)
+
+    if not all_files:
+        return []
+
+    signals_list: list[FileSignals] = []
+    skipped = 0
+
+    for rel_path in all_files:
+        full_path = repo_path / rel_path
+        content = _read_file_safe(full_path)
+
+        if content is None:
+            signals_list.append(FileSignals(path=rel_path))
+            skipped += 1
+            continue
+
+        signals = _extract_signals(rel_path, content)
+        signals.raw_score = _compute_raw_score(signals)
+        signals_list.append(signals)
+
+    ranked = _normalize_scores(signals_list)
+    ranked.sort(key=lambda r: (-r.score, r.path))
+
+    if max_files_to_scan is not None:
+        ranked = ranked[:max_files_to_scan]
+
+    audit.write(
+        run_id=run_id,
+        event_type="llm_call",  # reuse event type for consistency
+        actor="orchestrator",
+        payload={
+            "stage": "ranking",
+            "model": "static-analysis",
+            "backend": "static",
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "cost_usd": 0.0,
+            "total_files": len(all_files),
+            "skipped_files": skipped,
+            "ranked_files": len(ranked),
+        },
+    )
+
+    logger.info(
+        "Static ranking complete: %d files scored, %d skipped, top %d selected",
+        len(all_files), skipped, len(ranked),
+    )
+
+    return ranked

--- a/tests/unit/test_ranker.py
+++ b/tests/unit/test_ranker.py
@@ -86,6 +86,7 @@ async def test_api_failure_retries_then_raises(audit_log: AuditLog):
                     ranking_model="anthropic/claude-opus-4-6",
                     max_files_to_scan=None,
                     audit=audit_log,
+                    strategy="llm",
                 )
 
     assert mock_call.call_count == 3

--- a/tests/unit/test_static_ranker.py
+++ b/tests/unit/test_static_ranker.py
@@ -1,0 +1,333 @@
+"""Tests for the static analysis file ranker."""
+
+import asyncio
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from harness.static_ranker import (
+    FileSignals,
+    _build_reason,
+    _compute_raw_score,
+    _extract_signals,
+    _normalize_scores,
+    _read_file_safe,
+    _score_path_heuristic,
+    rank_files_static,
+)
+from harness.ranker import RankedFile
+
+
+# ---------------------------------------------------------------------------
+# _score_path_heuristic
+# ---------------------------------------------------------------------------
+
+
+def test_path_bonus_parser():
+    assert _score_path_heuristic("libavcodec/h264_parser.c") > 0
+
+
+def test_path_bonus_codec():
+    assert _score_path_heuristic("libavcodec/aac.c") > 0
+
+
+def test_path_bonus_format():
+    assert _score_path_heuristic("libavformat/mov.c") > 0
+
+
+def test_path_penalty_test():
+    assert _score_path_heuristic("tests/test_utils.c") < 0
+
+
+def test_path_penalty_doc():
+    assert _score_path_heuristic("doc/examples/helper.c") < 0
+
+
+def test_path_neutral():
+    assert _score_path_heuristic("libavutil/version.h") == 0
+
+
+# ---------------------------------------------------------------------------
+# _extract_signals
+# ---------------------------------------------------------------------------
+
+
+SAMPLE_UNSAFE = """
+#include <string.h>
+void foo(char *dst, const char *src) {
+    strcpy(dst, src);
+    strcat(dst, "suffix");
+    sprintf(dst, "%s", src);
+}
+"""
+
+SAMPLE_INPUT_SOURCES = """
+#include <stdio.h>
+void read_data(FILE *f, char *buf) {
+    fread(buf, 1, 1024, f);
+    fgets(buf, 1024, f);
+}
+"""
+
+SAMPLE_MEMORY = """
+#include <stdlib.h>
+void alloc_stuff() {
+    char *p = malloc(1024);
+    p = realloc(p, 2048);
+    free(p);
+}
+"""
+
+SAMPLE_POINTER_ARITH = """
+void process(char *buf, int offset) {
+    char c = *(buf + offset);
+    buf[offset + 1] = 0;
+}
+"""
+
+SAMPLE_COMPLEX = """
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+void parse_input(FILE *f) {
+    char *buf = malloc(4096);
+    fread(buf, 1, 4096, f);
+    strcpy(buf, "header");
+    memcpy(buf + 10, buf, 100);
+    char c = *(buf + 5);
+    free(buf);
+}
+"""
+
+
+def test_extract_unsafe_calls():
+    signals = _extract_signals("test.c", SAMPLE_UNSAFE)
+    assert signals.unsafe_calls == 3  # strcpy, strcat, sprintf
+
+
+def test_extract_input_sources():
+    signals = _extract_signals("test.c", SAMPLE_INPUT_SOURCES)
+    assert signals.input_sources == 2  # fread, fgets
+
+
+def test_extract_memory_mgmt():
+    signals = _extract_signals("test.c", SAMPLE_MEMORY)
+    assert signals.memory_mgmt == 3  # malloc, realloc, free
+
+
+def test_extract_pointer_arith():
+    signals = _extract_signals("test.c", SAMPLE_POINTER_ARITH)
+    assert signals.pointer_arith >= 2  # *(buf + offset), buf[offset + 1]
+
+
+def test_extract_memcpy():
+    signals = _extract_signals("test.c", SAMPLE_COMPLEX)
+    assert signals.memcpy_count == 1
+
+
+def test_extract_loc():
+    signals = _extract_signals("test.c", SAMPLE_UNSAFE)
+    assert signals.loc == SAMPLE_UNSAFE.count("\n") + 1
+
+
+def test_extract_complex_has_all_signals():
+    signals = _extract_signals("test.c", SAMPLE_COMPLEX)
+    assert signals.unsafe_calls >= 1
+    assert signals.input_sources >= 1
+    assert signals.memory_mgmt >= 2
+    assert signals.memcpy_count >= 1
+
+
+# ---------------------------------------------------------------------------
+# _compute_raw_score
+# ---------------------------------------------------------------------------
+
+
+def test_score_empty_file():
+    signals = FileSignals(path="empty.c", loc=0)
+    score = _compute_raw_score(signals)
+    assert score >= 0
+
+
+def test_source_sink_multiplier():
+    """Files with both input sources and unsafe calls get a 1.5x multiplier."""
+    base = FileSignals(path="test.c", loc=100, input_sources=2, unsafe_calls=3)
+    no_sink = FileSignals(path="test.c", loc=100, input_sources=2, unsafe_calls=0)
+
+    base.raw_score = _compute_raw_score(base)
+    no_sink.raw_score = _compute_raw_score(no_sink)
+
+    # source+sink should score higher than input-only
+    assert base.raw_score > no_sink.raw_score * 1.3
+
+
+def test_memory_pointer_multiplier():
+    """Files with both memory mgmt and pointer arith get a 1.3x multiplier."""
+    both = FileSignals(path="test.c", loc=100, memory_mgmt=5, pointer_arith=3)
+    mem_only = FileSignals(path="test.c", loc=100, memory_mgmt=5, pointer_arith=0)
+
+    both_score = _compute_raw_score(both)
+    mem_only_score = _compute_raw_score(mem_only)
+
+    assert both_score > mem_only_score
+
+
+def test_path_bonus_affects_score():
+    parser = FileSignals(path="codec/parser.c", loc=100, unsafe_calls=1, path_bonus=5.0)
+    plain = FileSignals(path="util/helper.c", loc=100, unsafe_calls=1, path_bonus=0.0)
+
+    assert _compute_raw_score(parser) > _compute_raw_score(plain)
+
+
+# ---------------------------------------------------------------------------
+# _normalize_scores
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_empty():
+    assert _normalize_scores([]) == []
+
+
+def test_normalize_single_file():
+    signals = [FileSignals(path="test.c", loc=100)]
+    signals[0].raw_score = 50.0
+    result = _normalize_scores(signals)
+    assert len(result) == 1
+    assert result[0].score == 3  # single file gets default
+
+
+def test_normalize_range():
+    signals = []
+    for i, raw in enumerate([0, 25, 50, 75, 100]):
+        s = FileSignals(path=f"file{i}.c", loc=100)
+        s.raw_score = raw
+        signals.append(s)
+
+    result = _normalize_scores(signals)
+    scores = [r.score for r in result]
+    assert scores[0] == 1  # lowest
+    assert scores[-1] == 5  # highest
+    # All scores in valid range
+    assert all(1 <= s <= 5 for s in scores)
+
+
+def test_normalize_all_same():
+    signals = []
+    for i in range(5):
+        s = FileSignals(path=f"file{i}.c", loc=100)
+        s.raw_score = 42.0
+        signals.append(s)
+
+    result = _normalize_scores(signals)
+    assert all(r.score == 3 for r in result)
+
+
+# ---------------------------------------------------------------------------
+# _build_reason
+# ---------------------------------------------------------------------------
+
+
+def test_reason_includes_signals():
+    signals = FileSignals(path="test.c", loc=200, unsafe_calls=5, input_sources=3)
+    reason = _build_reason(signals)
+    assert "5 unsafe calls" in reason
+    assert "3 input sources" in reason
+
+
+def test_reason_truncated():
+    signals = FileSignals(
+        path="test.c", loc=200,
+        unsafe_calls=99, input_sources=99, memory_mgmt=99,
+        pointer_arith=99, memcpy_count=99,
+    )
+    reason = _build_reason(signals)
+    assert len(reason) <= 120
+
+
+# ---------------------------------------------------------------------------
+# _read_file_safe
+# ---------------------------------------------------------------------------
+
+
+def test_read_normal_file(tmp_path):
+    f = tmp_path / "test.c"
+    f.write_text("int main() { return 0; }\n")
+    assert _read_file_safe(f) is not None
+
+
+def test_read_binary_file(tmp_path):
+    f = tmp_path / "test.bin"
+    f.write_bytes(b"\x00\x01\x02\x03" * 100)
+    assert _read_file_safe(f) is None
+
+
+def test_read_nonexistent():
+    assert _read_file_safe(Path("/nonexistent/file.c")) is None
+
+
+def test_read_oversized(tmp_path):
+    f = tmp_path / "huge.c"
+    f.write_bytes(b"x" * (3 * 1024 * 1024))  # 3MB
+    assert _read_file_safe(f) is None
+
+
+def test_read_latin1(tmp_path):
+    f = tmp_path / "test.c"
+    f.write_bytes(b"/* \xe9\xe8\xea */ int main() { return 0; }\n")
+    content = _read_file_safe(f)
+    assert content is not None
+    assert "int main()" in content
+
+
+# ---------------------------------------------------------------------------
+# rank_files_static (integration)
+# ---------------------------------------------------------------------------
+
+
+def test_rank_files_static_integration(tmp_path):
+    """End-to-end test with synthetic C files."""
+    from harness.audit import AuditLog
+
+    # Create a high-risk file
+    risky = tmp_path / "parser.c"
+    risky.write_text(SAMPLE_COMPLEX)
+
+    # Create a low-risk file
+    safe = tmp_path / "version.h"
+    safe.write_text('#define VERSION "1.0"\n')
+
+    audit = AuditLog(tmp_path / "audit.jsonl")
+
+    result = asyncio.run(rank_files_static(
+        run_id="test-run",
+        repo_path=tmp_path,
+        exclude_patterns=[],
+        max_files_to_scan=None,
+        audit=audit,
+    ))
+
+    assert len(result) == 2
+    # parser.c should rank higher than version.h
+    assert result[0].path == "parser.c"
+    assert result[0].score > result[1].score
+
+
+def test_rank_files_static_max_files(tmp_path):
+    """max_files_to_scan limits output."""
+    from harness.audit import AuditLog
+
+    for i in range(10):
+        (tmp_path / f"file{i}.c").write_text(f"void func{i}() {{ }}\n")
+
+    audit = AuditLog(tmp_path / "audit.jsonl")
+
+    result = asyncio.run(rank_files_static(
+        run_id="test-run",
+        repo_path=tmp_path,
+        exclude_patterns=[],
+        max_files_to_scan=3,
+        audit=audit,
+    ))
+
+    assert len(result) == 3

--- a/worker/entrypoint.sh
+++ b/worker/entrypoint.sh
@@ -23,69 +23,75 @@ cp -a /target/src /tmp/src
 cd /tmp/src
 git submodule update --init --recursive 2>/dev/null || true
 
-echo "=== compiling with AddressSanitizer ===" >&2
-export CC=clang
-export CFLAGS="-fsanitize=address -g -O1 -fno-omit-frame-pointer -fPIC"
-export LDFLAGS="-fsanitize=address"
-
-emit_build_failure() {
-    local output="$1"
-    local clean=$(echo "$output" | tail -5 | tr '\n' ' ' | sed 's/"/\\"/g' | head -c 500)
-    echo "{\"verdict\":\"not_found\",\"description\":\"Compilation failed\",\"reasoning\":\"${clean}\"}"
-    exit 1
-}
-
-# Build configure command: use CONFIGURE_FLAGS if provided, else default --disable-shared
-if [ -n "${CONFIGURE_FLAGS:-}" ]; then
-    CONF_CMD="./configure $CONFIGURE_FLAGS"
-else
-    CONF_CMD="./configure --disable-shared"
-fi
-
-# Try autotools first (configure or configure.ac)
-if [ -f ./configure ]; then
-    echo "Build system: configure (flags: ${CONFIGURE_FLAGS:---disable-shared})" >&2
-    BUILD_OUTPUT=$(eval "$CONF_CMD" 2>&1 && make -j"$(nproc)" 2>&1) || emit_build_failure "$BUILD_OUTPUT"
-elif [ -f ./configure.ac ] || [ -f ./configure.in ]; then
-    echo "Build system: autotools (needs autoreconf)" >&2
-    BUILD_OUTPUT=$(autoreconf -fi 2>&1 && eval "$CONF_CMD" 2>&1 && make -j"$(nproc)" 2>&1) || emit_build_failure "$BUILD_OUTPUT"
-elif [ -f CMakeLists.txt ]; then
-    echo "Build system: cmake" >&2
-    mkdir -p build && cd build
-    # Pass ASAN flags via cmake variables (not shell expansion)
-    BUILD_OUTPUT=$(cmake \
-        -DCMAKE_C_COMPILER=clang \
-        -DCMAKE_CXX_COMPILER=clang++ \
-        -DCMAKE_C_FLAGS="-fsanitize=address -g -O1 -fno-omit-frame-pointer -fPIC" \
-        -DCMAKE_CXX_FLAGS="-fsanitize=address -g -O1 -fno-omit-frame-pointer -fPIC" \
-        -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address" \
-        -DCMAKE_SHARED_LINKER_FLAGS="-fsanitize=address" \
-        -DCMAKE_BUILD_TYPE=Debug \
-        -DBUILD_SHARED_LIBS=OFF \
-        .. 2>&1 && make -j"$(nproc)" 2>&1) || emit_build_failure "$BUILD_OUTPUT"
-    cd ..
-elif [ -f Makefile ] || [ -f makefile ] || [ -f GNUmakefile ]; then
-    echo "Build system: plain Makefile" >&2
-    BUILD_OUTPUT=$(make CC=clang CFLAGS="$CFLAGS" LDFLAGS="$LDFLAGS" -j"$(nproc)" 2>&1) || true
-    # For Makefile projects, partial build is OK if we got the target binary
-    if ! find /tmp/src -maxdepth 3 -type f -executable -name "${BINARY_NAME}" 2>/dev/null | grep -q .; then
-        emit_build_failure "$BUILD_OUTPUT"
-    fi
-else
-    echo "{\"verdict\":\"not_found\",\"description\":\"No recognized build system found\",\"reasoning\":\"No configure, configure.ac, CMakeLists.txt, or Makefile\"}"
-    exit 1
-fi
-
-# Collect built binaries into a known location
 BINDIR=/tmp/bin
 mkdir -p "$BINDIR"
-find /tmp/src -type f -executable \
-    ! -name '*.sh' ! -name '*.py' ! -name '*.pl' ! -name '*.cmake' \
-    ! -name '*.sample' ! -name '*.so*' ! -name '*.o' \
-    ! -path '*/CMakeFiles/*' ! -path '*/.git/*' \
-    -exec cp -n {} "$BINDIR/" \; 2>/dev/null || true
+
+# Check if pre-compiled binaries were mounted at /target/bin
+if [ -d /target/bin ] && [ "$(ls -A /target/bin 2>/dev/null)" ]; then
+    echo "=== using pre-compiled binaries from /target/bin ===" >&2
+    cp -a /target/bin/* "$BINDIR/" 2>/dev/null || true
+else
+    echo "=== compiling with AddressSanitizer ===" >&2
+    export CC=clang
+    export CFLAGS="-fsanitize=address -g -O1 -fno-omit-frame-pointer -fPIC"
+    export LDFLAGS="-fsanitize=address"
+
+    emit_build_failure() {
+        local output="$1"
+        local clean=$(echo "$output" | tail -5 | tr '\n' ' ' | sed 's/"/\\"/g' | head -c 500)
+        echo "{\"verdict\":\"not_found\",\"description\":\"Compilation failed\",\"reasoning\":\"${clean}\"}"
+        exit 1
+    }
+
+    # Build configure command: use CONFIGURE_FLAGS if provided, else default --disable-shared
+    if [ -n "${CONFIGURE_FLAGS:-}" ]; then
+        CONF_CMD="./configure $CONFIGURE_FLAGS"
+    else
+        CONF_CMD="./configure --disable-shared"
+    fi
+
+    # Try autotools first (configure or configure.ac)
+    if [ -f ./configure ]; then
+        echo "Build system: configure (flags: ${CONFIGURE_FLAGS:---disable-shared})" >&2
+        BUILD_OUTPUT=$(eval "$CONF_CMD" 2>&1 && make -j"$(nproc)" 2>&1) || emit_build_failure "$BUILD_OUTPUT"
+    elif [ -f ./configure.ac ] || [ -f ./configure.in ]; then
+        echo "Build system: autotools (needs autoreconf)" >&2
+        BUILD_OUTPUT=$(autoreconf -fi 2>&1 && eval "$CONF_CMD" 2>&1 && make -j"$(nproc)" 2>&1) || emit_build_failure "$BUILD_OUTPUT"
+    elif [ -f CMakeLists.txt ]; then
+        echo "Build system: cmake" >&2
+        mkdir -p build && cd build
+        BUILD_OUTPUT=$(cmake \
+            -DCMAKE_C_COMPILER=clang \
+            -DCMAKE_CXX_COMPILER=clang++ \
+            -DCMAKE_C_FLAGS="-fsanitize=address -g -O1 -fno-omit-frame-pointer -fPIC" \
+            -DCMAKE_CXX_FLAGS="-fsanitize=address -g -O1 -fno-omit-frame-pointer -fPIC" \
+            -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address" \
+            -DCMAKE_SHARED_LINKER_FLAGS="-fsanitize=address" \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DBUILD_SHARED_LIBS=OFF \
+            .. 2>&1 && make -j"$(nproc)" 2>&1) || emit_build_failure "$BUILD_OUTPUT"
+        cd ..
+    elif [ -f Makefile ] || [ -f makefile ] || [ -f GNUmakefile ]; then
+        echo "Build system: plain Makefile" >&2
+        BUILD_OUTPUT=$(make CC=clang CFLAGS="$CFLAGS" LDFLAGS="$LDFLAGS" -j"$(nproc)" 2>&1) || true
+        if ! find /tmp/src -maxdepth 3 -type f -executable -name "${BINARY_NAME}" 2>/dev/null | grep -q .; then
+            emit_build_failure "$BUILD_OUTPUT"
+        fi
+    else
+        echo "{\"verdict\":\"not_found\",\"description\":\"No recognized build system found\",\"reasoning\":\"No configure, configure.ac, CMakeLists.txt, or Makefile\"}"
+        exit 1
+    fi
+
+    # Collect built binaries
+    find /tmp/src -type f -executable \
+        ! -name '*.sh' ! -name '*.py' ! -name '*.pl' ! -name '*.cmake' \
+        ! -name '*.sample' ! -name '*.so*' ! -name '*.o' \
+        ! -path '*/CMakeFiles/*' ! -path '*/.git/*' \
+        -exec cp -n {} "$BINDIR/" \; 2>/dev/null || true
+fi
+
 export PATH="$BINDIR:$PATH"
-echo "=== built binaries ===" >&2
+echo "=== available binaries ===" >&2
 ls "$BINDIR/" >&2 2>/dev/null || echo "(none found)" >&2
 
 export ASAN_OPTIONS="detect_leaks=1:abort_on_error=1:print_stacktrace=1"


### PR DESCRIPTION
## Summary
- **Static file ranker**: Replace LLM-based ranking with regex-based static analysis that reads actual source code — counts unsafe calls, input sources, memory ops, pointer arithmetic. Ranks 3,460 FFmpeg files in ~3 seconds at $0 cost (vs $2.50 + minutes for LLM ranker, which also failed on every batch due to max_tokens truncation)
- **Pre-compilation build step**: New `vuln-harness build` command compiles target once with ASAN, saves binaries. Workers mount via `--bin-dir`, skipping 10-15 min per-container compilation. Saves ~200 min of redundant compilation for a 20-file FFmpeg scan
- **Bug fixes**: `--disable-asm` for ARM/NEON on Apple Silicon, LLM ranker batch_size/max_tokens scaling

## Validation
Full FFmpeg 4.4 end-to-end pipeline completed:
- Static ranking: 3,460 files scored in ~3s, top 20 selected (codec/format parsers ranked highest)
- Pre-compiled FFmpeg binary mounted into 20 worker containers — all skipped compilation
- 20 containers dispatched successfully (agents hit API billing limit, but pipeline itself worked)

## New workflow
```bash
vuln-harness build --config harness-ffmpeg.yaml     # compile once (~10 min)
vuln-harness run --config harness-ffmpeg.yaml \      # scan with pre-compiled binaries
  --bin-dir runs/{build-run-id}/bin
```

## Test plan
- [x] 73/73 unit tests passing
- [x] Static ranker ranks FFmpeg files correctly (mov.c, codec parsers score 4-5)
- [x] Pre-compiled binaries mount and skip compilation in worker containers
- [x] LLM ranker still works with `ranking_strategy: llm`
- [ ] Full scan with valid API credits to confirm findings flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)