### PR TITLE
Update README to reflect current architecture and findings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,15 @@
+# IBM Enterprise Vulnerability Harness (vuln-harness)
+
+An autonomous defensive security research tool that finds, validates, and reports vulnerabilities in open-source C/C++ software. It uses a litellm-based ReAct agent loop as the agentic runtime inside isolated Docker containers, following the five-stage Anthropic methodology: file-ranking pre-pass, parallel isolated worker containers with AddressSanitizer verification, PoC generation, and validation agent filtering. The agent loop is provider-agnostic — any litellm-compatible model (Anthropic, OpenAI, Google, Ollama, etc.) works out of the box.
+
+Built for enterprise use in regulated industries including financial services and federal government. Satisfies NIST frameworks, applicable regulatory requirements, and IBM security standards with a tamper-evident SHA-3 hash-chained audit log designed for watsonx.governance ingestion.
 
 ## Prerequisites
 
 - **Docker** (with buildx) — for worker containers and local Redis/Postgres
 - **Python 3.12+** — orchestrator language
 - **uv** — Python package manager (`curl -LsSf https://astral.sh/uv/install.sh | sh`)
-- **Anthropic API key** — `ANTHROPIC_API_KEY` environment variable
+- **LLM provider API key** — at least one of `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GOOGLE_API_KEY`, etc. (any litellm-supported provider)
 - **OpenShift / IBM Cloud Code Engine** — for production deployment (optional for local dev)
 
 ## Local quickstart
@@ -26,7 +31,16 @@ cp harness.yaml.example harness.yaml
 # Edit harness.yaml: set repo_url, binary_name, project_name, etc.
 
 # 5. Run the full pipeline
-export ANTHROPIC_API_KEY=sk-ant-...
+# Set your LLM provider API key:
+export ANTHROPIC_API_KEY=sk-ant-...    # for Anthropic models
+# — or —
+export OPENAI_API_KEY=sk-...           # for OpenAI models
+
+# Override models via env vars (no YAML changes needed):
+# export WORKER_MODEL=openai/gpt-4o
+# export RANKING_MODEL=openai/gpt-4o
+# export VALIDATION_MODEL=openai/gpt-4o
+
 export FINDINGS_ENC_KEY=$(python3 -c "import os,base64; print(base64.b64encode(os.urandom(32)).decode())")
 vuln-harness run --config harness.yaml
 ```
@@ -35,17 +49,50 @@ vuln-harness run --config harness.yaml
 
 The harness operates as a five-stage pipeline managed by a Python asyncio orchestrator:
 
-1. **File ranking** — Single Anthropic Messages API call scores source files 1-5 by vulnerability likelihood
+1. **File ranking** — Static regex-based ranker scores source files 1-5 by vulnerability likelihood (default, free, instant). LLM-based ranking available as an alternative via `ranking_strategy: llm` in config.
 2. **Job dispatch** — Redis priority queue feeds parallel Docker containers (default 4, production 50)
-3. **Worker containers** — Claude Code in headless mode (`claude --print`) analyzes one file per container with ASAN-instrumented binaries
+3. **Worker containers** — litellm-based ReAct agent loop analyzes one file per container with ASAN-instrumented binaries. Target binaries are auto-built once before dispatch; pre-compiled binaries are reused across all workers.
 4. **ASAN parser** — Extracts crash metadata, assigns severity tier (1-5), estimates CVSS
-5. **Validation agent** — Separate Claude instance filters false positives before human review
+5. **Validation agent** — Separate LLM call via litellm filters false positives before human review
 
 Results flow into an encrypted Postgres findings store. Every action is logged to the SHA-3 hash-chained audit JSONL before any subsequent step. See `01-constitution.md` and `02-specification.md` for full details.
 
+## Validated findings
+
+The harness has been validated against giflib 5.1.4 (a known-vulnerable release), successfully discovering 3 vulnerabilities:
+
+| # | Type | Location | Severity | CVE |
+|---|------|----------|----------|-----|
+| 1 | heap-buffer-overflow (READ) | `util/gif2rgb.c:293` | Tier 3, CVSS 6.2 | CVE-2016-3977 |
+| 2 | stack-buffer-overflow (WRITE) | `util/gifbuild.c:242` | Tier 4, CVSS 8.2 | — |
+| 3 | heap-buffer-underflow (READ) | `lib/gifalloc.c:148` | Tier 3, CVSS 6.2 | — |
+
+All findings were validated by the validation agent and confirmed with AddressSanitizer output. See `FINDING_001_giflib_5_1_4.md` for full details including reproduction steps and candidate patches.
+
+## Model configuration
+
+All config fields can be overridden via environment variables — no YAML changes needed. Env vars take precedence over YAML values.
+
+```bash
+# Switch to OpenAI
+export OPENAI_API_KEY=sk-...
+export WORKER_MODEL=openai/gpt-4o
+export RANKING_MODEL=openai/gpt-4o
+export VALIDATION_MODEL=openai/gpt-4o
+vuln-harness run --config harness.yaml
+
+# Switch to Ollama (local)
+export WORKER_MODEL=ollama/llama3
+export RANKING_MODEL=ollama/llama3
+export VALIDATION_MODEL=ollama/llama3
+vuln-harness run --config harness.yaml
+```
+
+The YAML configs default to Anthropic models, but any [litellm-supported provider](https://docs.litellm.ai/docs/providers) works. Any field in `harness/config.py` can be overridden by setting an env var with the matching name.
+
 ## Constitution summary
 
-- **P1 — Isolation is absolute**: One permitted egress: `api.anthropic.com:443`. No inter-container comms.
+- **P1 — Isolation is absolute**: One permitted egress: the configured LLM provider API endpoint(s). No inter-container comms.
 - **P2 — Human review before external action**: No finding leaves the system without explicit human sign-off.
 - **P3 — Every action logged before execution**: Synchronous, hash-chained, tamper-evident audit JSONL.
 - **P4 — No credential persistence in images**: Secrets injected via env vars at runtime only.
@@ -57,8 +104,14 @@ Results flow into an encrypted Postgres findings store. Every action is logged t
 ## CLI reference
 
 ```bash
-# Full pipeline run
+# Pre-compile target with ASAN (binaries reused across workers)
+vuln-harness build --config harness.yaml
+
+# Full pipeline (auto-builds, then dispatches workers)
 vuln-harness run --config harness.yaml
+
+# Use pre-compiled binaries from a previous build
+vuln-harness run --config harness.yaml --bin-dir runs/<run-id>/bin
 
 # Stage 1 only: rank files by vulnerability likelihood
 vuln-harness rank --config harness.yaml
@@ -76,20 +129,55 @@ vuln-harness audit-verify --run-id <uuid>
 vuln-harness cost --run-id <uuid>
 ```
 
+## Development
+
+### Setup
+
+```bash
+make install          # install dependencies via uv
+make build-worker     # build the Docker worker image
+```
+
+### Quality checks
+
+```bash
+make test             # run unit tests with coverage
+make lint             # ruff check
+make format           # ruff format + fix
+make pre-commit       # run all pre-commit hooks
+```
+
+### Pre-commit hooks
+
+Install hooks locally:
+
+```bash
+uv run pre-commit install
+```
+
+Hooks run automatically on commit: ruff check/format, trailing whitespace, YAML/TOML validation, large file detection, AI artifact detection.
+
+### CI
+
+All PRs to main run:
+- **Pre-commit** — all hooks
+- **Lint** — ruff check + format check
+- **Tests** — pytest with coverage gate (50% overall; ~84% on unit-testable code)
+
 ## Moving to production
 
-**OpenShift deployment**: Replace Docker with OpenShift container runtime. Worker containers become OpenShift Jobs with resource limits enforced by the cluster. The `harness.yaml` `max_parallel_workers` maps to Job parallelism. Use OpenShift Secrets for `ANTHROPIC_API_KEY` and `FINDINGS_ENC_KEY`.
+**OpenShift deployment**: Replace Docker with OpenShift container runtime. Worker containers become OpenShift Jobs with resource limits enforced by the cluster. The `harness.yaml` `max_parallel_workers` maps to Job parallelism. Use OpenShift Secrets for API keys (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, etc.) and `FINDINGS_ENC_KEY`.
 
-**Network policy**: Replace the `scripts/setup-network.sh` iptables rules with OpenShift NetworkPolicy objects. The policy allows egress only to `api.anthropic.com:443` and denies all inter-pod communication. This is the production equivalent of the Docker bridge network isolation.
+**Network policy**: Replace the `scripts/setup-network.sh` iptables rules with OpenShift NetworkPolicy objects. The policy allows egress only to the configured LLM provider endpoint(s) and denies all inter-pod communication. This is the production equivalent of the Docker bridge network isolation.
 
 **watsonx.governance integration**: The audit JSONL format and SHA-3 hash chain are designed for direct ingestion by watsonx.governance. Integration is a one-day task: POST each audit entry to the governance endpoint after the local write succeeds. The hash chain provides tamper evidence; watsonx.governance provides retention, search, and compliance reporting.
 
 ## Cost expectations
 
-- **File ranking**: ~$0.10-0.30 per batch of 200 files (single API call)
-- **Worker container**: ~$1-5 per file depending on turn count and model (claude-opus-4-6)
+- **File ranking**: Free with static ranker (default). ~$0.10-0.30 per batch of 200 files with LLM ranking.
+- **Worker container**: ~$1-5 per file depending on turn count and model
 - **Validation**: ~$0.05-0.15 per finding (single API call)
 - **10-file scan**: ~$10-50 total depending on complexity and model choice
 - **Full project scan (100 files)**: ~$100-500; use `max_files_to_scan` and `max_run_spend_usd` to control
 
-Use `worker_model: claude-sonnet-4-6` in `harness.yaml` to reduce per-file cost by ~5x at the expense of some analysis depth.
+Costs vary by provider and model. Use a smaller model (e.g. `anthropic/claude-sonnet-4-6` or `openai/gpt-4o-mini`) in `harness.yaml` to reduce per-file cost at the expense of some analysis depth.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# IBM Enterprise Vulnerability Harness (vuln-harness)
+# Mantis — Autonomous Vulnerability Discovery Harness
 
 An autonomous defensive security research tool that finds, validates, and reports vulnerabilities in open-source C/C++ software. It uses a litellm-based ReAct agent loop as the agentic runtime inside isolated Docker containers, following the five-stage Anthropic methodology: file-ranking pre-pass, parallel isolated worker containers with AddressSanitizer verification, PoC generation, and validation agent filtering. The agent loop is provider-agnostic — any litellm-compatible model (Anthropic, OpenAI, Google, Ollama, etc.) works out of the box.
 
-Built for enterprise use in regulated industries including financial services and federal government. Satisfies NIST frameworks, applicable regulatory requirements, and IBM security standards with a tamper-evident SHA-3 hash-chained audit log designed for watsonx.governance ingestion.
+Built for enterprise use in regulated industries. Satisfies NIST frameworks and applicable regulatory requirements with a tamper-evident SHA-3 hash-chained audit log.
 
 ## Prerequisites
 
@@ -10,7 +10,7 @@ Built for enterprise use in regulated industries including financial services an
 - **Python 3.12+** — orchestrator language
 - **uv** — Python package manager (`curl -LsSf https://astral.sh/uv/install.sh | sh`)
 - **LLM provider API key** — at least one of `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GOOGLE_API_KEY`, etc. (any litellm-supported provider)
-- **OpenShift / IBM Cloud Code Engine** — for production deployment (optional for local dev)
+- **Kubernetes** — for production deployment (optional for local dev)
 
 ## Local quickstart
 
@@ -166,11 +166,11 @@ All PRs to main run:
 
 ## Moving to production
 
-**OpenShift deployment**: Replace Docker with OpenShift container runtime. Worker containers become OpenShift Jobs with resource limits enforced by the cluster. The `harness.yaml` `max_parallel_workers` maps to Job parallelism. Use OpenShift Secrets for API keys (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, etc.) and `FINDINGS_ENC_KEY`.
+**Kubernetes deployment**: Replace Docker with Kubernetes Jobs. Worker containers become Jobs with resource limits enforced by the cluster. The `harness.yaml` `max_parallel_workers` maps to Job parallelism. Use Kubernetes Secrets for API keys (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, etc.) and `FINDINGS_ENC_KEY`.
 
-**Network policy**: Replace the `scripts/setup-network.sh` iptables rules with OpenShift NetworkPolicy objects. The policy allows egress only to the configured LLM provider endpoint(s) and denies all inter-pod communication. This is the production equivalent of the Docker bridge network isolation.
+**Network policy**: Replace the `scripts/setup-network.sh` iptables rules with Kubernetes NetworkPolicy objects. The policy allows egress only to the configured LLM provider endpoint(s) and denies all inter-pod communication. This is the production equivalent of the Docker bridge network isolation.
 
-**watsonx.governance integration**: The audit JSONL format and SHA-3 hash chain are designed for direct ingestion by watsonx.governance. Integration is a one-day task: POST each audit entry to the governance endpoint after the local write succeeds. The hash chain provides tamper evidence; watsonx.governance provides retention, search, and compliance reporting.
+**Governance integration**: The audit JSONL format and SHA-3 hash chain are designed for direct ingestion by governance platforms. Integration is a one-day task: POST each audit entry to the governance endpoint after the local write succeeds. The hash chain provides tamper evidence; the governance platform provides retention, search, and compliance reporting.
 
 ## Cost expectations
 

--- a/README.md
+++ b/README.md
@@ -47,15 +47,19 @@ vuln-harness run --config harness.yaml
 
 ## Architecture overview
 
+<p align="center">
+  <img src="docs/architecture.svg" alt="Mantis pipeline architecture" width="900"/>
+</p>
+
 The harness operates as a five-stage pipeline managed by a Python asyncio orchestrator:
 
 1. **File ranking** — Static regex-based ranker scores source files 1-5 by vulnerability likelihood (default, free, instant). LLM-based ranking available as an alternative via `ranking_strategy: llm` in config.
-2. **Job dispatch** — Redis priority queue feeds parallel Docker containers (default 4, production 50)
-3. **Worker containers** — litellm-based ReAct agent loop analyzes one file per container with ASAN-instrumented binaries. Target binaries are auto-built once before dispatch; pre-compiled binaries are reused across all workers.
-4. **ASAN parser** — Extracts crash metadata, assigns severity tier (1-5), estimates CVSS
-5. **Validation agent** — Separate LLM call via litellm filters false positives before human review
+2. **Job queue** — Redis sorted set prioritizes files by vulnerability score, feeds parallel Docker workers.
+3. **Worker containers** — Each container runs a litellm-based ReAct agent loop against one source file with ASAN-instrumented binaries. The agent reads code, forms hypotheses, crafts malformed inputs, and runs them against the binary. Target binaries are auto-built once before dispatch and reused across all workers.
+4. **ASAN parser + triage** — Extracts crash metadata from AddressSanitizer output, assigns severity tier (1-5), estimates CVSS.
+5. **Validation agent** — Separate LLM call via litellm reviews each finding: is the ASAN output real? Is the reproduction plausible? Filters false positives before human review.
 
-Results flow into an encrypted Postgres findings store. Every action is logged to the SHA-3 hash-chained audit JSONL before any subsequent step. See `01-constitution.md` and `02-specification.md` for full details.
+Results flow into markdown reports and an optional encrypted Postgres findings store. Every action is logged to the SHA-3 hash-chained audit JSONL before any subsequent step. See `01-constitution.md` and `02-specification.md` for full details.
 
 ## Validated findings
 

--- a/docs/architecture.svg
+++ b/docs/architecture.svg
@@ -1,0 +1,124 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 520" font-family="system-ui, -apple-system, sans-serif" font-size="13">
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 7" refX="10" refY="3.5" markerWidth="10" markerHeight="7" orient="auto-start-auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#64748b"/>
+    </marker>
+    <marker id="arrow-green" viewBox="0 0 10 7" refX="10" refY="3.5" markerWidth="10" markerHeight="7" orient="auto-start-auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#16a34a"/>
+    </marker>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:#f8fafc"/>
+      <stop offset="100%" style="stop-color:#f1f5f9"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Background -->
+  <rect width="900" height="520" rx="12" fill="url(#bg)" stroke="#e2e8f0" stroke-width="1"/>
+
+  <!-- Title -->
+  <text x="450" y="32" text-anchor="middle" font-size="16" font-weight="bold" fill="#0f172a">Mantis — Five-Stage Vulnerability Discovery Pipeline</text>
+
+  <!-- Stage 1: File Ranking -->
+  <rect x="30" y="60" width="160" height="80" rx="8" fill="#eff6ff" stroke="#3b82f6" stroke-width="1.5"/>
+  <text x="110" y="82" text-anchor="middle" font-weight="bold" fill="#1e40af" font-size="11">STAGE 1</text>
+  <text x="110" y="100" text-anchor="middle" font-weight="bold" fill="#1e3a5f">File Ranking</text>
+  <text x="110" y="118" text-anchor="middle" fill="#475569" font-size="11">Static regex (default)</text>
+  <text x="110" y="132" text-anchor="middle" fill="#475569" font-size="11">or LLM via litellm</text>
+
+  <!-- Arrow 1→Build -->
+  <line x1="190" y1="100" x2="218" y2="100" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow)"/>
+
+  <!-- Auto-Build -->
+  <rect x="220" y="60" width="150" height="80" rx="8" fill="#fefce8" stroke="#ca8a04" stroke-width="1.5"/>
+  <text x="295" y="82" text-anchor="middle" font-weight="bold" fill="#854d0e" font-size="11">AUTO-BUILD</text>
+  <text x="295" y="100" text-anchor="middle" font-weight="bold" fill="#1e3a5f">ASAN Compile</text>
+  <text x="295" y="118" text-anchor="middle" fill="#475569" font-size="11">clang + sanitizers</text>
+  <text x="295" y="132" text-anchor="middle" fill="#475569" font-size="11">build once, reuse</text>
+
+  <!-- Arrow Build→Queue -->
+  <line x1="370" y1="100" x2="398" y2="100" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow)"/>
+
+  <!-- Stage 2: Job Queue -->
+  <rect x="400" y="60" width="140" height="80" rx="8" fill="#eff6ff" stroke="#3b82f6" stroke-width="1.5"/>
+  <text x="470" y="82" text-anchor="middle" font-weight="bold" fill="#1e40af" font-size="11">STAGE 2</text>
+  <text x="470" y="100" text-anchor="middle" font-weight="bold" fill="#1e3a5f">Job Queue</text>
+  <text x="470" y="118" text-anchor="middle" fill="#475569" font-size="11">Redis sorted set</text>
+  <text x="470" y="132" text-anchor="middle" fill="#475569" font-size="11">priority by score</text>
+
+  <!-- Arrow Queue→Workers -->
+  <line x1="470" y1="140" x2="470" y2="175" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow)"/>
+
+  <!-- Stage 3: Worker Containers (larger box) -->
+  <rect x="100" y="180" width="740" height="130" rx="8" fill="#f0fdf4" stroke="#16a34a" stroke-width="1.5"/>
+  <text x="470" y="200" text-anchor="middle" font-weight="bold" fill="#166534" font-size="11">STAGE 3 — PARALLEL WORKER CONTAINERS (Docker, isolated)</text>
+
+  <!-- Worker 1 -->
+  <rect x="120" y="215" width="165" height="80" rx="6" fill="white" stroke="#86efac" stroke-width="1"/>
+  <text x="202" y="235" text-anchor="middle" font-weight="bold" fill="#1e3a5f" font-size="11">Worker 1</text>
+  <text x="202" y="252" text-anchor="middle" fill="#475569" font-size="10">litellm ReAct loop</text>
+  <text x="202" y="266" text-anchor="middle" fill="#475569" font-size="10">Read code → Hypothesize</text>
+  <text x="202" y="280" text-anchor="middle" fill="#475569" font-size="10">→ Craft input → Run ASAN</text>
+
+  <!-- Worker 2 -->
+  <rect x="300" y="215" width="165" height="80" rx="6" fill="white" stroke="#86efac" stroke-width="1"/>
+  <text x="382" y="235" text-anchor="middle" font-weight="bold" fill="#1e3a5f" font-size="11">Worker 2</text>
+  <text x="382" y="252" text-anchor="middle" fill="#475569" font-size="10">litellm ReAct loop</text>
+  <text x="382" y="266" text-anchor="middle" fill="#475569" font-size="10">Read code → Hypothesize</text>
+  <text x="382" y="280" text-anchor="middle" fill="#475569" font-size="10">→ Craft input → Run ASAN</text>
+
+  <!-- Worker N -->
+  <rect x="490" y="215" width="165" height="80" rx="6" fill="white" stroke="#86efac" stroke-width="1"/>
+  <text x="572" y="235" text-anchor="middle" font-weight="bold" fill="#1e3a5f" font-size="11">Worker 3</text>
+  <text x="572" y="252" text-anchor="middle" fill="#475569" font-size="10">litellm ReAct loop</text>
+  <text x="572" y="266" text-anchor="middle" fill="#475569" font-size="10">Read code → Hypothesize</text>
+  <text x="572" y="280" text-anchor="middle" fill="#475569" font-size="10">→ Craft input → Run ASAN</text>
+
+  <!-- Worker ... -->
+  <rect x="670" y="215" width="150" height="80" rx="6" fill="white" stroke="#86efac" stroke-width="1" stroke-dasharray="4,3"/>
+  <text x="745" y="260" text-anchor="middle" fill="#94a3b8" font-size="12">Worker N...</text>
+
+  <!-- Arrow Workers→Parser -->
+  <line x1="470" y1="310" x2="470" y2="345" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow)"/>
+
+  <!-- Stage 4: ASAN Parser -->
+  <rect x="250" y="350" width="200" height="70" rx="8" fill="#eff6ff" stroke="#3b82f6" stroke-width="1.5"/>
+  <text x="350" y="372" text-anchor="middle" font-weight="bold" fill="#1e40af" font-size="11">STAGE 4</text>
+  <text x="350" y="390" text-anchor="middle" font-weight="bold" fill="#1e3a5f">ASAN Parser + Triage</text>
+  <text x="350" y="407" text-anchor="middle" fill="#475569" font-size="11">Severity tier 1-5, CVSS estimate</text>
+
+  <!-- Arrow Parser→Validator -->
+  <line x1="450" y1="385" x2="488" y2="385" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow)"/>
+
+  <!-- Stage 5: Validation -->
+  <rect x="490" y="350" width="200" height="70" rx="8" fill="#fdf2f8" stroke="#db2777" stroke-width="1.5"/>
+  <text x="590" y="372" text-anchor="middle" font-weight="bold" fill="#9d174d" font-size="11">STAGE 5</text>
+  <text x="590" y="390" text-anchor="middle" font-weight="bold" fill="#1e3a5f">Validation Agent</text>
+  <text x="590" y="407" text-anchor="middle" fill="#475569" font-size="11">LLM filters false positives</text>
+
+  <!-- Arrow Validator→Outputs -->
+  <line x1="470" y1="420" x2="470" y2="450" stroke="#16a34a" stroke-width="1.5" marker-end="url(#arrow-green)"/>
+
+  <!-- Outputs row -->
+  <rect x="100" y="455" width="170" height="45" rx="6" fill="#faf5ff" stroke="#9333ea" stroke-width="1"/>
+  <text x="185" y="475" text-anchor="middle" font-weight="bold" fill="#7e22ce" font-size="11">Findings (Markdown)</text>
+  <text x="185" y="490" text-anchor="middle" fill="#475569" font-size="10">runs/{id}/findings/*.md</text>
+
+  <rect x="290" y="455" width="170" height="45" rx="6" fill="#faf5ff" stroke="#9333ea" stroke-width="1"/>
+  <text x="375" y="475" text-anchor="middle" font-weight="bold" fill="#7e22ce" font-size="11">Encrypted Postgres</text>
+  <text x="375" y="490" text-anchor="middle" fill="#475569" font-size="10">AES-256-GCM at rest</text>
+
+  <rect x="480" y="455" width="170" height="45" rx="6" fill="#faf5ff" stroke="#9333ea" stroke-width="1"/>
+  <text x="565" y="475" text-anchor="middle" font-weight="bold" fill="#7e22ce" font-size="11">Audit Log</text>
+  <text x="565" y="490" text-anchor="middle" fill="#475569" font-size="10">SHA-3 hash-chained JSONL</text>
+
+  <rect x="670" y="455" width="170" height="45" rx="6" fill="#fff7ed" stroke="#ea580c" stroke-width="1"/>
+  <text x="755" y="475" text-anchor="middle" font-weight="bold" fill="#c2410c" font-size="11">Human Review</text>
+  <text x="755" y="490" text-anchor="middle" fill="#475569" font-size="10">Required before disclosure</text>
+
+  <!-- LLM Provider label -->
+  <rect x="720" y="60" width="150" height="80" rx="8" fill="#f8fafc" stroke="#cbd5e1" stroke-width="1" stroke-dasharray="4,3"/>
+  <text x="795" y="82" text-anchor="middle" font-weight="bold" fill="#64748b" font-size="11">LLM PROVIDER</text>
+  <text x="795" y="100" text-anchor="middle" fill="#475569" font-size="11">via litellm</text>
+  <text x="795" y="118" text-anchor="middle" fill="#475569" font-size="10">Anthropic / OpenAI</text>
+  <text x="795" y="132" text-anchor="middle" fill="#475569" font-size="10">Google / Ollama / ...</text>
+</svg>

--- a/poc/giflib-5.1.4/gen_gifbuild_stack_overflow.py
+++ b/poc/giflib-5.1.4/gen_gifbuild_stack_overflow.py
@@ -28,14 +28,16 @@ lines = [
 for i in range(94):
     lines.append(f"\trgb {i % 256} {i % 256} {i % 256} is A\n")
 
-lines.extend([
-    "end\n",
-    "\n",
-    "image\n",
-    "image top 0\n",
-    "image left 0\n",
-    "image bits 1 by 1\n",
-    "A\n",
-])
+lines.extend(
+    [
+        "end\n",
+        "\n",
+        "image\n",
+        "image top 0\n",
+        "image left 0\n",
+        "image bits 1 by 1\n",
+        "A\n",
+    ]
+)
 
 sys.stdout.writelines(lines)


### PR DESCRIPTION
## Summary

- Rewrites README to match the current state after PRs #1 (litellm agent loop), #2 (configure_flags/FFmpeg), and #3 (static ranker/pre-compilation) landed
- Replaces all Claude Code / Anthropic-specific references with provider-agnostic litellm-based ReAct agent loop
- Adds **Validated findings** section with giflib 5.1.4 results (3 vulnerabilities including CVE-2016-3977)
- Adds **Development** section covering Makefile, pre-commit hooks, and CI (from PR #9)
- Updates CLI reference with `build` command and `--bin-dir` flag (from PR #5)
- Updates cost section to note static ranker is free and costs vary by provider

Supersedes closed PR #6.

## Test plan

- [ ] Verify all markdown renders correctly on GitHub
- [ ] Confirm no broken links or formatting issues
- [ ] Cross-check architecture stages against `01-constitution.md` and `harness/config.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)