### PR TITLE
Add CI/CD pipeline and build automation

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,0 +1,53 @@
+# ===============================================================
+# Docker Worker Image Build — Build Verification Gate
+# ===============================================================
+#
+#   Builds the worker Docker image to verify it compiles.
+#   Does NOT push to any registry — build-only verification.
+#   Uses GitHub Actions cache for faster builds.
+#
+#   Triggers on PRs to main when worker or Dockerfile changes.
+#   Skips draft PRs.
+# ---------------------------------------------------------------
+
+name: Build Worker Image
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review]
+    branches: [main]
+    paths:
+      - "worker/**"
+      - "worker/Dockerfile"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    if: "!github.event.pull_request.draft"
+    name: Docker build (worker)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+
+      - name: Build worker image
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198571cfb76f00 # v6.18.0
+        with:
+          context: worker
+          file: worker/Dockerfile
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,86 @@
+# ===============================================================
+# Integration Tests — Full Stack Gate
+# ===============================================================
+#
+#   Spins up Redis + Postgres service containers and runs
+#   the full test suite including integration tests.
+#
+#   Triggers on PRs to main when harness, tests, or
+#   docker-compose config changes. Skips draft PRs.
+# ---------------------------------------------------------------
+
+name: Integration Tests
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review]
+    branches: [main]
+    paths:
+      - "harness/**"
+      - "tests/**"
+      - "docker-compose.yml"
+      - ".github/workflows/integration.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  integration:
+    if: "!github.event.pull_request.draft"
+    name: Integration tests (Redis + Postgres)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    env:
+      PYTHONUNBUFFERED: "1"
+      REDIS_URL: redis://localhost:6379
+      POSTGRES_URL: postgresql://postgres:postgres@localhost:5432/mantis_test
+
+    services:
+      redis:
+        image: redis:7
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+      postgres:
+        image: postgres:16
+        ports:
+          - 5432:5432
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: mantis_test
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Run all tests (unit + integration)
+        run: make test-all

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,9 +33,13 @@ permissions:
 jobs:
   test:
     if: "!github.event.pull_request.draft"
-    name: pytest (py3.12)
+    name: pytest (py${{ matrix.python-version }})
     runs-on: ubuntu-latest
     timeout-minutes: 15
+
+    strategy:
+      matrix:
+        python-version: ["3.12", "3.13"]
 
     env:
       PYTHONUNBUFFERED: "1"
@@ -46,10 +50,10 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up Python 3.12
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: "3.12"
+          python-version: ${{ matrix.python-version }}
 
       - name: Set up uv
         uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
@@ -72,6 +76,7 @@ jobs:
         run: |
           uv run pytest \
             --ignore=tests/integration \
+            --strict-markers \
             --cov=harness \
             --cov-report=term \
             --cov-fail-under=50

--- a/Makefile
+++ b/Makefile
@@ -46,15 +46,18 @@ services-down:
 # help:
 # help: QUALITY
 # help: check            - Run all quality checks (lint + format-check + test)
+# help: ci               - Run lint + format-check + test (mirrors CI pipeline)
 # help: lint             - Run ruff linter on all Python source
 # help: format           - Auto-format code and fix lint issues
 # help: format-check     - Check formatting without modifying files
 # help: pre-commit       - Run all pre-commit hooks against all files
 # =============================================================================
 
-.PHONY: check lint format format-check pre-commit
+.PHONY: check ci lint format format-check pre-commit
 
 check: lint format-check test
+
+ci: lint format-check test
 
 lint:
 	uv run ruff check harness/ worker/ tests/

--- a/docs/branch-protection.md
+++ b/docs/branch-protection.md
@@ -1,0 +1,46 @@
+# Branch Protection Settings
+
+Recommended GitHub branch protection rules for `main`.
+
+## Required Settings
+
+### Require pull request reviews before merging
+
+- Require at least **1 approving review**
+- Dismiss stale reviews when new commits are pushed
+- Require review from code owners (if `CODEOWNERS` file exists)
+
+### Require status checks to pass before merging
+
+Enable the following required status checks:
+
+| Status Check              | Workflow                    |
+|---------------------------|-----------------------------|
+| `pytest (py3.12)`         | Tests & Coverage            |
+| `pytest (py3.13)`         | Tests & Coverage            |
+| `Ruff lint & format check`| Lint & Static Analysis     |
+| `Run pre-commit hooks`    | Pre-commit Checks           |
+
+- **Require branches to be up to date before merging** — ensures the PR is
+  tested against the latest `main` before it can land.
+
+### Restrict force pushes
+
+- **Do not allow force pushes** to `main`. Force pushes rewrite history and
+  can break other contributors' branches.
+
+### Additional recommendations
+
+- **Do not allow deletions** — prevent accidental deletion of `main`.
+- **Require linear history** (optional) — enforces squash or rebase merges
+  for a cleaner commit log.
+- **Require signed commits** (optional) — adds an extra layer of commit
+  authenticity verification.
+
+## Applying These Settings
+
+1. Go to **Settings > Branches** in the GitHub repository.
+2. Click **Add branch protection rule**.
+3. Set **Branch name pattern** to `main`.
+4. Enable the settings listed above.
+5. Click **Create** (or **Save changes**).


### PR DESCRIPTION
## Summary

- **build-image.yml** — builds the Docker worker image on PRs touching `worker/` or `Dockerfile` using `docker/build-push-action` with GitHub Actions cache (build-only, no registry push)
- **integration.yml** — spins up Redis 7 + Postgres 16 service containers with health checks, runs `make test-all` for full integration test coverage
- **test.yml** — adds Python 3.13 to the test matrix and `--strict-markers` flag to pytest
- **Makefile** — adds `make ci` target that runs `lint + format-check + test`, mirroring the CI pipeline locally
- **docs/branch-protection.md** — documents recommended GitHub branch protection settings (required reviews, status checks, no force push)

Closes #12

## Test plan

- [x] Verify `build-image.yml` triggers only on PRs changing `worker/**` or `Dockerfile`
- [x] Verify `integration.yml` service containers start with correct health checks
- [x] Verify test matrix runs on both Python 3.12 and 3.13
- [x] Verify `make ci` runs lint, format-check, and test sequentially
- [x] Review branch protection doc for completeness

🤖 Generated with [Claude Code](https://claude.com/claude-code)