### PR TITLE
Supply chain security: Docker image hardening

### DIFF
--- a/.github/workflows/image-security.yml
+++ b/.github/workflows/image-security.yml
@@ -1,0 +1,74 @@
+# ===============================================================
+# Image Security — Vulnerability Scan & SBOM
+# ===============================================================
+#
+#   Builds the worker Docker image, runs a Trivy vulnerability
+#   scan, and generates a CycloneDX SBOM as a build artifact.
+#   Triggers on PRs to main when worker files change.
+# ---------------------------------------------------------------
+
+name: Image Security
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review]
+    branches: [main]
+    paths:
+      - "worker/**"
+      - ".github/workflows/image-security.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    if: "!github.event.pull_request.draft"
+    name: Build, scan & SBOM
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      # ---------------------------------------------------------------
+      # Build the worker image
+      # ---------------------------------------------------------------
+      - name: Build worker image
+        run: cd worker && docker build -t vuln-harness-worker:latest .
+
+      # ---------------------------------------------------------------
+      # Trivy vulnerability scan (continue-on-error: base image may
+      # have known CVEs that we accept for now)
+      # ---------------------------------------------------------------
+      - name: Run Trivy vulnerability scan
+        uses: aquasecurity/trivy-action@18f2510ee396bbf400402947e7f25d18f1229e19 # v0.28.0
+        continue-on-error: true
+        with:
+          image-ref: vuln-harness-worker:latest
+          severity: CRITICAL,HIGH
+          exit-code: "1"
+          format: table
+
+      # ---------------------------------------------------------------
+      # Generate CycloneDX SBOM with Syft
+      # ---------------------------------------------------------------
+      - name: Generate SBOM
+        uses: anchore/sbom-action@e11c554f704a0b820cbf8c51673f6945e0731532 # v0.18.0
+        with:
+          image: vuln-harness-worker:latest
+          format: cyclonedx-json
+          output-file: sbom.json
+
+      - name: Upload SBOM artifact
+        uses: actions/upload-artifact@ea165f8d65b6db9a8b76aff02472626f1ef6aea8 # v4.6.2
+        with:
+          name: sbom
+          path: sbom.json
+          retention-days: 90

--- a/.github/workflows/image-security.yml
+++ b/.github/workflows/image-security.yml
@@ -48,7 +48,7 @@ jobs:
       # have known CVEs that we accept for now)
       # ---------------------------------------------------------------
       - name: Run Trivy vulnerability scan
-        uses: aquasecurity/trivy-action@18f2510ee396bbf400402947e7f25d18f1229e19 # v0.28.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         continue-on-error: true
         with:
           image-ref: vuln-harness-worker:latest
@@ -60,14 +60,14 @@ jobs:
       # Generate CycloneDX SBOM with Syft
       # ---------------------------------------------------------------
       - name: Generate SBOM
-        uses: anchore/sbom-action@e11c554f704a0b820cbf8c51673f6945e0731532 # v0.18.0
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
           image: vuln-harness-worker:latest
           format: cyclonedx-json
           output-file: sbom.json
 
       - name: Upload SBOM artifact
-        uses: actions/upload-artifact@ea165f8d65b6db9a8b76aff02472626f1ef6aea8 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: sbom
           path: sbom.json

--- a/Makefile
+++ b/Makefile
@@ -118,6 +118,21 @@ build-target:
 
 # =============================================================================
 # help:
+# help: SECURITY
+# help: scan-image       - Scan worker Docker image with Trivy
+# help: sbom             - Generate CycloneDX SBOM with Syft
+# =============================================================================
+
+.PHONY: scan-image sbom
+
+scan-image:
+	./scripts/scan-image.sh
+
+sbom:
+	./scripts/generate-sbom.sh
+
+# =============================================================================
+# help:
 # help: CLEANUP
 # help: clean            - Remove build and cache artifacts
 # =============================================================================

--- a/scripts/generate-sbom.sh
+++ b/scripts/generate-sbom.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# ================================================================
+# generate-sbom.sh — Generate a CycloneDX SBOM for the worker image
+# ================================================================
+set -euo pipefail
+
+IMAGE="${1:-vuln-harness-worker:latest}"
+OUTPUT="sbom.json"
+
+# ── Pre-flight: check for syft ──────────────────────────────────
+if ! command -v syft &>/dev/null; then
+    echo "ERROR: syft is not installed." >&2
+    echo "" >&2
+    echo "Install instructions:" >&2
+    echo "  brew install syft          # macOS" >&2
+    echo "  curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin" >&2
+    echo "  https://github.com/anchore/syft#installation" >&2
+    exit 1
+fi
+
+# ── Generate SBOM ────────────────────────────────────────────────
+echo "Generating CycloneDX SBOM for ${IMAGE}..."
+
+syft "${IMAGE}" -o cyclonedx-json > "${OUTPUT}"
+
+echo "SBOM written to ${OUTPUT}"

--- a/scripts/scan-image.sh
+++ b/scripts/scan-image.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# ================================================================
+# scan-image.sh — Scan the worker Docker image for vulnerabilities
+# ================================================================
+set -euo pipefail
+
+IMAGE="${1:-vuln-harness-worker:latest}"
+
+# ── Pre-flight: check for trivy ─────────────────────────────────
+if ! command -v trivy &>/dev/null; then
+    echo "ERROR: trivy is not installed." >&2
+    echo "" >&2
+    echo "Install instructions:" >&2
+    echo "  brew install trivy          # macOS" >&2
+    echo "  sudo apt-get install trivy  # Debian/Ubuntu (add aquasecurity repo first)" >&2
+    echo "  https://aquasecurity.github.io/trivy/latest/getting-started/installation/" >&2
+    exit 1
+fi
+
+# ── Run scan ─────────────────────────────────────────────────────
+echo "Scanning ${IMAGE} for CRITICAL and HIGH vulnerabilities..."
+echo ""
+
+trivy image --severity CRITICAL,HIGH --exit-code 1 "${IMAGE}"
+STATUS=$?
+
+echo ""
+if [ $STATUS -eq 0 ]; then
+    echo "PASS: No CRITICAL or HIGH vulnerabilities found."
+else
+    echo "FAIL: Vulnerabilities detected (exit code ${STATUS})."
+fi
+
+exit $STATUS

--- a/worker/.dockerignore
+++ b/worker/.dockerignore
@@ -1,0 +1,20 @@
+# Version control
+.git
+.gitignore
+
+# Python artifacts
+*.pyc
+__pycache__
+.venv
+.env
+
+# Test & coverage
+.coverage
+.pytest_cache
+
+# Documentation (keep README)
+*.md
+!README.md
+
+# Scan output
+runs/

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -50,6 +50,7 @@ RUN echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/99no-check-
     && apt-get update && apt-get install -y --no-install-recommends \
     # --- compilers & sanitizer runtime ---
     clang \
+    libclang-rt-18-dev \
     libasan8 \
     # --- debuggers ---
     lldb \

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,14 +1,61 @@
-FROM ubuntu:24.04
+# ================================================================
+# Mantis Worker — Multi-stage Docker Build
+# ================================================================
+#
+# Stage 1 (builder): installs all apt + pip dependencies.
+# Stage 2 (runtime): copies installed packages, agent code, and
+#   tools needed at runtime (clang, make, cmake, autoconf, gdb,
+#   lldb, valgrind) — the entrypoint compiles target projects
+#   inside the container, so build tools must be present.
+#
+# The multi-stage split keeps pip build artifacts, apt caches,
+# and header-only dev packages out of the final image.
+# ----------------------------------------------------------------
+
+# ── Stage 1: builder ────────────────────────────────────────────
+FROM ubuntu:24.04 AS builder
+
+LABEL stage=builder
 
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/99no-check-valid \
     && echo 'Acquire::Check-Date "false";' >> /etc/apt/apt.conf.d/99no-check-valid \
-    && apt-get update && apt-get install -y \
+    && apt-get update && apt-get install -y --no-install-recommends \
+    python3 \
+    python3-pip \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Python dependencies into a known prefix so we can copy them
+COPY agent/ /agent/
+RUN pip3 install --break-system-packages --no-cache-dir jinja2 \
+    && pip3 install --break-system-packages --no-cache-dir -r /agent/requirements.txt
+
+# ── Stage 2: runtime ───────────────────────────────────────────
+FROM ubuntu:24.04 AS runtime
+
+# OCI image labels
+LABEL org.opencontainers.image.source="https://github.com/manavgup/mantis"
+LABEL org.opencontainers.image.description="Mantis vulnerability-discovery worker — ASAN-instrumented builds and ReAct agent loop"
+LABEL org.opencontainers.image.licenses="MIT"
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Runtime packages — the entrypoint compiles target projects with ASAN,
+# so we need compilers, build systems, and debuggers at runtime.
+# Versions are pinned to the ubuntu:24.04 repository; use `apt-cache policy <pkg>`
+# inside the base image to refresh pins after a base image bump.
+RUN echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/99no-check-valid \
+    && echo 'Acquire::Check-Date "false";' >> /etc/apt/apt.conf.d/99no-check-valid \
+    && apt-get update && apt-get install -y --no-install-recommends \
+    # --- compilers & sanitizer runtime ---
     clang \
+    libasan8 \
+    # --- debuggers ---
     lldb \
     gdb \
     valgrind \
+    # --- build systems (needed by entrypoint to compile targets) ---
     build-essential \
     cmake \
     autoconf \
@@ -16,18 +63,19 @@ RUN echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/99no-check-
     libtool \
     pkg-config \
     nasm \
+    # --- utilities ---
     git \
     python3 \
     python3-pip \
     curl \
     && rm -rf /var/lib/apt/lists/*
 
-# Jinja2 for prompt rendering in entrypoint
-RUN pip3 install --break-system-packages jinja2
+# Copy pip-installed packages from builder stage
+COPY --from=builder /usr/lib/python3/dist-packages/ /usr/lib/python3/dist-packages/
+COPY --from=builder /usr/local/lib/python3.12/dist-packages/ /usr/local/lib/python3.12/dist-packages/
 
-# Agent loop dependencies (litellm for provider-agnostic LLM access)
+# Agent loop code
 COPY agent/ /agent/
-RUN pip3 install --break-system-packages --no-cache-dir -r /agent/requirements.txt
 
 # Create non-root user (UID 1001 — 1000 may be taken in base image)
 RUN useradd -m -u 1001 researcher


### PR DESCRIPTION
## Summary
- **Multi-stage Dockerfile**: Builder stage installs pip dependencies (jinja2, litellm); runtime stage copies only installed packages, keeping pip build artifacts and apt caches out of the final image. Added `--no-install-recommends`, `libasan8`, and OCI labels (`org.opencontainers.image.source`, `description`, `licenses`).
- **`.dockerignore`**: Excludes `.git`, `*.pyc`, `__pycache__`, `.env`, `.venv`, `runs/`, test/coverage artifacts from the Docker build context.
- **`scripts/scan-image.sh`**: Runs Trivy vulnerability scan (CRITICAL + HIGH) against the worker image; checks for trivy installation and prints instructions if missing.
- **`scripts/generate-sbom.sh`**: Generates a CycloneDX SBOM via Syft; checks for syft installation and prints instructions if missing.
- **`.github/workflows/image-security.yml`**: PR workflow (path-filtered to `worker/**`) that builds the image, runs Trivy (continue-on-error since base image may have known CVEs), generates SBOM, and uploads it as a build artifact.
- **Makefile targets**: `make scan-image` and `make sbom` for local use.

Closes #13

## Test plan
- [ ] `cd worker && docker build -t vuln-harness-worker:latest .` builds successfully with the multi-stage Dockerfile
- [ ] Container starts and entrypoint compiles a target project (clang, make, cmake, autoconf all present at runtime)
- [x] `make scan-image` runs trivy (or prints install instructions if trivy is absent)
- [x] `make sbom` runs syft (or prints install instructions if syft is absent)
- [ ] `.dockerignore` excludes expected files from build context
- [ ] GitHub Actions workflow triggers on PRs touching `worker/**`

🤖 Generated with [Claude Code](https://claude.com/claude-code)