### PR TITLE
Rewrite architecture.md -- fix inaccuracies and add missing components

### DIFF
--- a/03-plan.md
+++ b/03-plan.md
@@ -94,7 +94,7 @@ class Config(BaseSettings):
 
 ### `harness/ranker.py`
 
-Direct `anthropic` SDK call — not Claude Code. Uses `client.messages.create`. Batches up to 200 file paths per call. Returns `list[RankedFile]`. Writes result to `{run_dir}/file_rankings.json`. Logs the API call (model, input tokens, output tokens, cost) to audit log before returning.
+Direct LLM ranking call via the orchestrator abstraction layer — not the worker agent runtime. Batches up to 200 file paths per call. Returns `list[RankedFile]`. Writes result to `{run_dir}/file_rankings.json`. Logs the API call (model, input tokens, output tokens, cost) to audit log before returning.
 
 Key function signature:
 ```python
@@ -136,7 +136,7 @@ The dispatcher loop runs until queue is empty or spend limit is hit.
 
 ### `harness/parser.py`
 
-Pure Python, no external calls. Parses the JSON blob from Claude Code's `--output-format json` output. Extracts ASAN crash metadata using regex patterns against `asan_output` field. Assigns severity tier per taxonomy in spec. Computes CVSS estimate heuristic.
+Pure Python, no external calls. Parses the JSON blob from the worker agent's final structured output. Extracts ASAN crash metadata using regex patterns against `asan_output` field. Assigns severity tier per taxonomy in spec. Computes CVSS estimate heuristic.
 
 ASAN output patterns to extract:
 ```python
@@ -239,13 +239,9 @@ RUN apt-get update && apt-get install -y \
     curl \
     && rm -rf /var/lib/apt/lists/*
 
-# Node.js (required by Claude Code)
-RUN curl -fsSL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash - \
-    && apt-get install -y nodejs \
-    && rm -rf /var/lib/apt/lists/*
-
-# Claude Code CLI — installed at build time, no credential needed
-RUN npm install -g @anthropic-ai/claude-code
+# Worker runtime dependencies
+# The current implementation uses a Python + litellm ReAct loop inside the
+# container, so no Claude Code CLI dependency is required.
 
 # Create non-root user
 RUN useradd -m -u 1000 researcher
@@ -351,8 +347,8 @@ dev-dependencies = [
 
 ## Key technical decisions and rationale
 
-**Why Claude Code CLI (`claude -p`) not the Agent SDK directly?**
-The Anthropic red team explicitly used Claude Code. It provides the full agentic loop — tool execution, multi-turn reasoning, shell access — with battle-tested prompt caching and compaction built in. The Agent SDK is lower-level and would require reimplementing what Claude Code already handles. Use the same tool Anthropic used.
+**Why a custom litellm-based ReAct loop instead of a Claude-specific runtime?**
+Provider lock-in is a poor fit for Mantis. The worker needs multi-turn reasoning plus tool execution, but those behaviors can be implemented directly with a small ReAct loop and a narrow tool surface (`bash`, `read_file`). That keeps the worker portable across Anthropic, OpenAI, Google, Ollama, and other litellm-compatible backends while preserving the same overall methodology.
 
 **Why asyncio for the orchestrator?**
 Container dispatch is I/O-bound, not CPU-bound. We're waiting for containers to finish, not computing. `asyncio` with a semaphore gives clean concurrency control without threading complexity.
@@ -369,5 +365,5 @@ Exploit reproduction commands and patches are sensitive — they could enable at
 **Why build the target binary outside the container?**
 Actually we build inside the container (in entrypoint.sh) because the ASAN-instrumented binary must match the container's clang version exactly. The source is mounted read-only; the build artifacts go to /workspace which is tmpfs.
 
-**Why `--output-format json` for Claude Code?**
-Gives us structured, parseable output from the agent's final turn. We still capture stderr for raw ASAN output which the agent may not have included verbatim in its JSON.
+**Why require structured JSON from the worker agent?**
+Gives us parseable output from the agent's final turn regardless of backend. We still capture stderr for raw ASAN output which the agent may not have included verbatim in its JSON.

--- a/04-tasks.md
+++ b/04-tasks.md
@@ -1,6 +1,6 @@
 # Tasks
 # Mantis — Autonomous Vulnerability Discovery Harness
-# Implementation order for Claude Code
+# Implementation order
 
 ## How to use this file
 
@@ -215,7 +215,7 @@ docker run --rm \
   vuln-harness-worker:latest 2>&1 | tee /tmp/worker-output.json
 ```
 
-**Verify**: Output is valid JSON. `verdict` field is present. Agent made multiple bash calls (visible in Claude Code's turn output). Run completed without container crash.
+**Verify**: Output is valid JSON. `verdict` field is present. Agent made multiple bash calls (visible in worker stderr / tool trace output). Run completed without container crash.
 
 ---
 
@@ -371,12 +371,12 @@ Write complete README covering:
 
 ---
 
-## Implementation notes for Claude Code
+## Implementation notes
 
 - Use `uv` exclusively for Python package management. Never use `pip` directly.
 - All async code uses `asyncio`. No threads except in `audit.py` write lock.
 - All Anthropic API calls use the official `anthropic` Python SDK, not raw HTTP.
-- Claude Code CLI is invoked via `asyncio.create_subprocess_exec`, not `subprocess.run` (blocking).
+- The worker agent runtime must remain provider-agnostic; do not introduce a Claude-specific runtime dependency.
 - All file paths use `pathlib.Path`, never string concatenation.
 - All datetime objects are timezone-aware UTC. Use `datetime.now(timezone.utc)`.
 - All UUIDs use `uuid.uuid4()`. Never use sequential IDs for security-relevant identifiers.

--- a/CLIENT_DEMO.md
+++ b/CLIENT_DEMO.md
@@ -8,7 +8,7 @@
 
 ## TL;DR
 
-We built a working implementation of Anthropic's **Glasswing/Mythos** autonomous vulnerability discovery methodology. The pipeline successfully performs real security research using Claude Code agents inside isolated Docker containers against AddressSanitizer-instrumented binaries. All five stages of the methodology are operational, audit logging is compliance-ready, and we have evidence from production runs that the agents conduct rigorous hypothesis-driven investigation.
+We built a working implementation of Anthropic's **Glasswing/Mythos** autonomous vulnerability discovery methodology. The pipeline successfully performs real security research using provider-agnostic litellm-based ReAct agents inside isolated Docker containers against AddressSanitizer-instrumented binaries. All five stages of the methodology are operational, audit logging is compliance-ready, and we have evidence from production runs that the agents conduct rigorous hypothesis-driven investigation.
 
 ---
 
@@ -27,7 +27,7 @@ An LLM scores every source file 1-5 by vulnerability likelihood. High-risk files
 Redis priority queue feeds parallel Docker containers. Concurrency controls, spend limits, and timeout management all enforced. Every action logged before execution.
 
 ### Stage 3 — Worker Containers (the core)
-Each container runs **Claude Code in headless mode** against one file:
+Each container runs a **litellm-based ReAct agent** against one file:
 - Reads the source code
 - Forms hypotheses about memory safety bugs
 - Crafts malformed inputs (python scripts)
@@ -35,7 +35,7 @@ Each container runs **Claude Code in headless mode** against one file:
 - Reads ASAN crash output
 - Iterates — this is the Glasswing hypothesis-test loop
 
-Isolated network (single egress: `api.anthropic.com:443`), read-only source, tmpfs workspace, dropped capabilities, memory/CPU limits.
+Isolated network (egress only to configured LLM provider endpoint(s)), read-only source, tmpfs workspace, dropped capabilities, memory/CPU limits.
 
 ### Stage 4 — ASAN Parser & Triage
 Extracts crash metadata, assigns severity tier 1-5, computes CVSS estimate:
@@ -46,7 +46,7 @@ Extracts crash metadata, assigns severity tier 1-5, computes CVSS estimate:
 - Tier 1: Memory leak (CVSS 1.0-3.5)
 
 ### Stage 5 — Validation Agent
-Separate Claude instance reviews each finding: *"Is the ASAN output real? Is the reproduction plausible? Is this a meaningful security issue?"* Filters false positives before human review.
+Separate validation-model call reviews each finding: *"Is the ASAN output real? Is the reproduction plausible? Is this a meaningful security issue?"* Filters false positives before human review.
 
 ---
 
@@ -106,7 +106,7 @@ Every finding requires **explicit human sign-off** before any external action.
 ## Infrastructure Ready for Production
 
 - **Python 3.12** async orchestrator with full test coverage (35 unit tests, 8 integration tests — all passing)
-- **Docker** worker containers with Claude Code 2.1.104, clang 18.1.3, multi-build-system support (autotools, CMake, plain Makefile)
+- **Docker** worker containers with a litellm-based ReAct worker, clang 18.1.3, multi-build-system support (autotools, CMake, plain Makefile)
 - **Redis** priority queue with atomic spend tracking
 - **Postgres** encrypted findings store
 - **SHA-3 audit log** with chain verification CLI

--- a/FINDING_001_giflib_5_1_4.md
+++ b/FINDING_001_giflib_5_1_4.md
@@ -2,7 +2,7 @@
 
 **Target**: giflib 5.1.4
 **Discovered by**: Mantis
-**Original harness**: Claude Code agent (sonnet-4-6), 2026-04-14
+**Original harness (historical baseline)**: Claude Code agent (sonnet-4-6), 2026-04-14
 **Updated harness**: litellm-based ReAct agent loop, 2026-04-25
 **Total validated findings**: 3
 
@@ -25,7 +25,7 @@ The updated litellm-based harness was run twice against giflib 5.1.4. Both runs 
 | `3fb19f15-879e-4d40-8d67-21d74c5324ae` | 2026-04-25 | #1, #2, #3 (3 findings) |
 | `d49e47aa-18b0-41d4-a842-f9c346940808` | 2026-04-25 | #1, #2 (2 findings) |
 
-Finding #1 was originally discovered on 2026-04-14 using the Claude Code CLI-based harness (12 of 40 turns, cost $0.74) and has now been replicated by the updated litellm-based harness in both independent runs.
+Finding #1 was originally discovered on 2026-04-14 using a Claude Code CLI-based baseline run (12 of 40 turns, cost $0.74) and has now been replicated by the updated litellm-based harness in both independent runs.
 
 ---
 
@@ -35,7 +35,7 @@ Finding #1 was originally discovered on 2026-04-14 using the Claude Code CLI-bas
 **Severity Tier**: 3 (arbitrary read)
 **CVSS Estimate**: 6.2 (High) -- unconfirmed, awaits human review
 **File**: `util/gif2rgb.c:293` in `DumpScreen2RGB`
-**Original discovery**: Mantis (Claude Code agent, sonnet-4-6), 2026-04-14 (12 of 40 turns, $0.74)
+**Original discovery**: Mantis historical baseline run (Claude Code agent, sonnet-4-6), 2026-04-14 (12 of 40 turns, $0.74)
 **Replicated**: 2026-04-25 by litellm-based harness in run `3fb19f15` (finding `a976bacd`) and run `d49e47aa` (finding `19e74e56`)
 
 ### Description

--- a/architecture.md
+++ b/architecture.md
@@ -2,9 +2,9 @@
 
 ## Overview
 
-Mantis is a five-stage pipeline for autonomous vulnerability discovery in C/C++ projects. A Python asyncio orchestrator manages the full lifecycle: ranking source files by vulnerability likelihood, dispatching isolated Docker containers that each run a provider-agnostic LLM agent loop with AddressSanitizer-instrumented binaries, parsing and triaging crash output, validating findings with a separate LLM call, and producing encrypted findings and human-review reports. Every action is logged to a SHA-3 hash-chained audit trail before any subsequent step executes.
+Mantis is a five-stage pipeline for autonomous vulnerability discovery in C/C++ projects. A Python asyncio orchestrator manages the full lifecycle: ranking source files by vulnerability likelihood, dispatching isolated Docker containers that each run a provider-agnostic LLM agent loop with sanitizer-instrumented binaries, parsing and triaging crash output, validating findings with a separate LLM call, and producing encrypted findings and human-review reports. Every action is logged to a SHA-3 hash-chained audit trail before any subsequent step executes.
 
-The system follows a "build once, scan many" model. ASAN binaries are compiled a single time in a builder container and then mounted read-only into every worker container. This eliminates redundant compilation, reduces per-container runtime by minutes, and ensures every worker tests the same binary. Workers never modify the source or the binary -- they only craft inputs and observe ASAN output.
+The system follows a "build once, scan many" model. Binaries instrumented with the configured sanitizer set are compiled a single time in a builder container and then mounted read-only into every worker container. This eliminates redundant compilation, reduces per-container runtime by minutes, and ensures every worker tests the same binary. Workers never modify the source or the binary -- they only craft inputs and observe sanitizer output.
 
 All LLM calls route through litellm, making the system provider-agnostic. The default model is `anthropic/claude-opus-4-6` but any litellm-compatible model string works (`openai/gpt-4o`, `ollama/llama3`, etc.). Each stage's model is independently configurable via YAML or environment variables, with env vars taking precedence. File ranking defaults to a free, instant static regex ranker -- LLM ranking is available as an alternative.
 
@@ -26,9 +26,9 @@ All LLM calls route through litellm, making the system provider-agnostic. The de
    +--------------------------------------------------------------+
    |  STAGE 0 -- BUILD (one-time)                                  |
    |                                                               |
-   |  Builder container: Clang + ASAN flags                        |
+   |  Builder container: Clang + configured sanitizer flags        |
    |  Auto-detects build system (configure / autotools / cmake /   |
-   |  Makefile), compiles with -fsanitize=address -g -O1           |
+   |  Makefile), compiles with the configured sanitizer set        |
    |  Collects binaries to host bin/ dir                           |
    |                                                               |
    |  Key files:                                                   |
@@ -73,7 +73,8 @@ All LLM calls route through litellm, making the system provider-agnostic. The de
    | bash      | | bash      | | bash      | | bash      |
    | read_file | | read_file | | read_file | | read_file |
    | GDB/LLDB  | | GDB/LLDB  | | GDB/LLDB  | | GDB/LLDB  |
-   | ASAN bin  | | ASAN bin  | | ASAN bin  | | ASAN bin  |
+   | Sanitized | | Sanitized | | Sanitized | | Sanitized |
+   | binary    | | binary    | | binary    | | binary    |
    |           | |           | |           | |           |
    | Egress:   | | Egress:   | | Egress:   | | Egress:   |
    | LLM API   | | LLM API   | | LLM API   | | LLM API   |
@@ -84,9 +85,9 @@ All LLM calls route through litellm, making the system provider-agnostic. The de
                 |
                 v
    +--------------------------------------------------------------+
-   |  STAGE 4 -- ASAN PARSER + TRIAGE                              |
+   |  STAGE 4 -- SANITIZER PARSER + TRIAGE                         |
    |                                                               |
-   |  Extract crash metadata -> Assign severity tier -> Est. CVSS  |
+   |  Extract crash/runtime metadata -> Assign severity -> Est. CVSS|
    |                                                               |
    |  Tier 5: Control flow hijack (RIP/PC control)   CVSS 9.0-10  |
    |  Tier 4: Arbitrary write (heap-buffer-overflow)  CVSS 7.5-9.0 |
@@ -130,7 +131,7 @@ All LLM calls route through litellm, making the system provider-agnostic. The de
 
 ## Stage 0 -- Build (pre-compilation)
 
-**What it does**: Compiles the target project once with Clang and AddressSanitizer flags (`-fsanitize=address -g -O1 -fno-omit-frame-pointer`). The builder container auto-detects the build system (configure, autotools, cmake, or plain Makefile), applies optional `configure_flags` from config, and copies all resulting executables to a host directory.
+**What it does**: Compiles the target project once with Clang and the configured sanitizer set (`asan`, `ubsan`, `msan`, `tsan`, or valid combinations). The builder container auto-detects the build system (configure, autotools, cmake, or plain Makefile), applies optional `configure_flags` from config, and copies all resulting executables to a host directory.
 
 **Key files**:
 - `harness/cli.py` -- `_build_asan_binaries()` launches the builder container, `_BUILD_SCRIPT` is the in-container build logic
@@ -175,7 +176,7 @@ All LLM calls route through litellm, making the system provider-agnostic. The de
 
 ## Stage 3 -- Worker containers (ReAct agent loop)
 
-**What it does**: Each container receives one source file to analyze. The entrypoint renders a Jinja2 task prompt, copies source to a writable tmpfs, sets up the ASAN binary on PATH, and invokes the Python ReAct agent loop. The agent reads code, forms vulnerability hypotheses, crafts malformed inputs, runs the ASAN binary, and reads crash output. If it triggers a crash, it reports a structured JSON verdict to stdout.
+**What it does**: Each container receives one source file to analyze. The entrypoint renders a Jinja2 task prompt, copies source to a writable tmpfs, sets up the prebuilt sanitized binary on PATH, and invokes the Python ReAct agent loop. The agent reads code, forms vulnerability hypotheses, crafts malformed inputs, runs the instrumented binary, and reads crash/runtime output. If it triggers a sanitizer finding, it reports a structured JSON verdict to stdout.
 
 **Key files**:
 - `worker/agent/loop.py` -- `agent_loop()`: the core ReAct loop using `litellm.completion()` with tool_choice="auto"
@@ -195,10 +196,10 @@ All LLM calls route through litellm, making the system provider-agnostic. The de
 
 ## Stage 4 -- ASAN parser and triage
 
-**What it does**: Parses agent JSON output and container stderr for AddressSanitizer crash signatures. Extracts vulnerability type, read/write direction, source location (function, file, line). Assigns a severity tier (1-5) and estimates CVSS based on the tier.
+**What it does**: Parses agent JSON output and container stderr for sanitizer signatures across ASan, UBSan, MSan, and TSan. Extracts vulnerability type, read/write direction where applicable, source location (function, file, line). Assigns a severity tier (1-5) and estimates CVSS based on the tier.
 
 **Key files**:
-- `harness/parser.py` -- `parse_result()`, severity/CVSS maps, ASAN regex patterns
+- `harness/parser.py` -- `parse_result()`, severity/CVSS maps, sanitizer regex patterns
 
 **Severity tiers**:
 
@@ -211,7 +212,7 @@ All LLM calls route through litellm, making the system provider-agnostic. The de
 | 1 | Memory leak only | 1.0 - 3.5 |
 
 **Design decisions**:
-- **Regex-based extraction**: ASAN output has a predictable format. Regex extraction is reliable and requires no LLM call.
+- **Regex-based extraction**: sanitizer output has a predictable format. Regex extraction is reliable and requires no LLM call.
 - **Conservative CVSS**: The estimate is the midpoint of the tier's range. Human reviewers must confirm or override (P7).
 
 ---
@@ -292,8 +293,9 @@ The allowed domains are configurable via `ALLOWED_API_DOMAINS` env var. All othe
                 |  +----------+-------------+  |
                 |             v                |
                 |  +------------------------+  |
-                |  | 4. Run ASAN binary      |  |
-                |  |    with crafted input   |  |
+                |  | 4. Run instrumented     |  |
+                |  |    binary with crafted  |  |
+                |  |    input                |  |
                 |  +----------+-------------+  |
                 |             v                |
                 |  +------------------------+  |

--- a/architecture.md
+++ b/architecture.md
@@ -1,150 +1,385 @@
-# Mantis — Architecture
+# Mantis -- Architecture
+
+## Overview
+
+Mantis is a five-stage pipeline for autonomous vulnerability discovery in C/C++ projects. A Python asyncio orchestrator manages the full lifecycle: ranking source files by vulnerability likelihood, dispatching isolated Docker containers that each run a provider-agnostic LLM agent loop with AddressSanitizer-instrumented binaries, parsing and triaging crash output, validating findings with a separate LLM call, and producing encrypted findings and human-review reports. Every action is logged to a SHA-3 hash-chained audit trail before any subsequent step executes.
+
+The system follows a "build once, scan many" model. ASAN binaries are compiled a single time in a builder container and then mounted read-only into every worker container. This eliminates redundant compilation, reduces per-container runtime by minutes, and ensures every worker tests the same binary. Workers never modify the source or the binary -- they only craft inputs and observe ASAN output.
+
+All LLM calls route through litellm, making the system provider-agnostic. The default model is `anthropic/claude-opus-4-6` but any litellm-compatible model string works (`openai/gpt-4o`, `ollama/llama3`, etc.). Each stage's model is independently configurable via YAML or environment variables, with env vars taking precedence. File ranking defaults to a free, instant static regex ranker -- LLM ranking is available as an alternative.
+
+---
+
+## Pipeline diagram
 
 ```
-┌─────────────────────────────────────────────────────────────────────────────┐
-│                           TARGET REPOSITORY                                 │
-│                     (C/C++ open-source project)                             │
-└──────────────────────────────┬──────────────────────────────────────────────┘
-                               │
-                               ▼
-┌─────────────────────────────────────────────────────────────────────────────┐
-│  STAGE 1 — FILE RANKING                                                     │
-│                                                                             │
-│  Claude Code / Anthropic API                                                │
-│  "Score each file 1-5 by vulnerability likelihood"                          │
-│                                                                             │
-│  ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐         │
-│  │parser.c  │ │decode.c  │ │alloc.c   │ │utils.c   │ │config.h  │         │
-│  │ score: 5 │ │ score: 5 │ │ score: 4 │ │ score: 2 │ │ score: 1 │         │
-│  └──────────┘ └──────────┘ └──────────┘ └──────────┘ └──────────┘         │
-└──────────────────────────────┬──────────────────────────────────────────────┘
-                               │ priority queue
-                               ▼
-┌─────────────────────────────────────────────────────────────────────────────┐
-│  STAGE 2 — JOB DISPATCH                                                     │
-│                                                                             │
-│  ┌───────────┐    ┌──────────────────────────────────┐                      │
-│  │   Redis    │◄──│  Orchestrator (Python/asyncio)    │                      │
-│  │  Priority  │    │  • Semaphore (N parallel)        │                      │
-│  │   Queue    │    │  • Spend limit enforcement       │                      │
-│  └───────────┘    │  • Timeout management (SIGKILL)   │                      │
-│                    └──────────────────────────────────┘                      │
-└────────┬───────────────┬───────────────┬───────────────┬────────────────────┘
-         │               │               │               │
-         ▼               ▼               ▼               ▼
-┌──────────────┐ ┌──────────────┐ ┌──────────────┐ ┌──────────────┐
-│  STAGE 3     │ │  STAGE 3     │ │  STAGE 3     │ │  STAGE 3     │
-│  WORKER      │ │  WORKER      │ │  WORKER      │ │  WORKER      │
-│  CONTAINER   │ │  CONTAINER   │ │  CONTAINER   │ │  CONTAINER   │
-│              │ │              │ │              │ │              │
-│ ┌──────────┐ │ │ ┌──────────┐ │ │ ┌──────────┐ │ │ ┌──────────┐ │
-│ │Claude    │ │ │ │Claude    │ │ │ │Claude    │ │ │ │Claude    │ │
-│ │Code      │ │ │ │Code      │ │ │ │Code      │ │ │ │Code      │ │
-│ │(headless)│ │ │ │(headless)│ │ │ │(headless)│ │ │ │(headless)│ │
-│ └────┬─────┘ │ │ └────┬─────┘ │ │ └────┬─────┘ │ │ └────┬─────┘ │
-│      │       │ │      │       │ │      │       │ │      │       │
-│      ▼       │ │      ▼       │ │      ▼       │ │      ▼       │
-│ ┌──────────┐ │ │ ┌──────────┐ │ │ ┌──────────┐ │ │ ┌──────────┐ │
-│ │ Bash     │ │ │ │ Bash     │ │ │ │ Bash     │ │ │ │ Bash     │ │
-│ │ GDB/LLDB │ │ │ │ GDB/LLDB │ │ │ │ GDB/LLDB │ │ │ │ GDB/LLDB │ │
-│ │ ASAN     │ │ │ │ ASAN     │ │ │ │ ASAN     │ │ │ │ ASAN     │ │
-│ │ Binary   │ │ │ │ Binary   │ │ │ │ Binary   │ │ │ │ Binary   │ │
-│ └──────────┘ │ │ └──────────┘ │ │ └──────────┘ │ │ └──────────┘ │
-│              │ │              │ │              │ │              │
-│  parser.c    │ │  decode.c    │ │  alloc.c     │ │  io.c        │
-│  Egress:     │ │  Egress:     │ │  Egress:     │ │  Egress:     │
-│  api.anthropic│ │  api.anthropic│ │  api.anthropic│ │  api.anthropic│
-│  .com:443    │ │  .com:443    │ │  .com:443    │ │  .com:443    │
-│  ONLY        │ │  ONLY        │ │  ONLY        │ │  ONLY        │
-└──────┬───────┘ └──────┬───────┘ └──────┬───────┘ └──────┬───────┘
-       │                │                │                │
-       │   ┌────────────────────────────────────────┐     │
-       └──►│         Raw findings (JSONL)            │◄───┘
-            └───────────────────┬────────────────────┘
-                                │
-                                ▼
-┌─────────────────────────────────────────────────────────────────────────────┐
-│  STAGE 4 — ASAN PARSER + TRIAGE                                             │
-│                                                                             │
-│  Extract crash metadata → Assign severity tier → Estimate CVSS              │
-│                                                                             │
-│  Tier 5: Control flow hijack (RIP/PC control)          CVSS 9.0-10.0       │
-│  Tier 4: Arbitrary write (heap-buffer-overflow WRITE)  CVSS 7.5-9.0        │
-│  Tier 3: Arbitrary read (use-after-free READ)          CVSS 5.0-7.5        │
-│  Tier 2: Crash / DoS (null deref, stack overflow)      CVSS 3.5-5.0        │
-│  Tier 1: Memory leak only                              CVSS 1.0-3.5        │
-└──────────────────────────────┬──────────────────────────────────────────────┘
-                               │
-                               ▼
-┌─────────────────────────────────────────────────────────────────────────────┐
-│  STAGE 5 — VALIDATION AGENT                                                 │
-│                                                                             │
-│  Separate Claude instance per finding:                                      │
-│  "Is the ASAN output real? Is the repro plausible? Is this meaningful?"     │
-│                                                                             │
-│  ┌─────────┐     ┌──────────────────┐     ┌─────────┐                      │
-│  │VALIDATE │     │NEEDS_HUMAN_TRIAGE│     │ REJECT  │                      │
-│  │→ review │     │→ review (flagged)│     │→ log    │                      │
-│  └────┬────┘     └────────┬─────────┘     └────┬────┘                      │
-│       │                   │                     │                           │
-└───────┼───────────────────┼─────────────────────┼───────────────────────────┘
-        │                   │                     │
-        ▼                   ▼                     ▼
-┌─────────────────────────────────────────────────────────────────────────────┐
-│                                                                             │
-│  ┌─────────────────┐  ┌─────────────────┐  ┌─────────────────────────────┐ │
-│  │  FINDINGS STORE  │  │  AUDIT LOG      │  │  HUMAN REVIEW PACKAGE      │ │
-│  │  (Postgres)      │  │  (JSONL)        │  │  (Markdown per finding)    │ │
-│  │                  │  │                 │  │                            │ │
-│  │  • AES-256-GCM   │  │  • SHA-3 hash   │  │  • Description             │ │
-│  │    encrypted     │  │    chained      │  │  • Reproduction steps      │ │
-│  │  • Exploit code  │  │  • Every action │  │  • ASAN output             │ │
-│  │    never in      │  │    logged BEFORE│  │  • Candidate patch         │ │
-│  │    plaintext     │  │    execution    │  │  • Reviewer sign-off box   │ │
-│  │                  │  │  • Tamper-      │  │                            │ │
-│  │                  │  │    evident      │  │  ☐ Confirmed real          │ │
-│  │                  │  │  • Governance   │  │  ☐ CVSS confirmed: ___    │ │
-│  │                  │  │    compatible   │  │  ☐ Disclosure approved     │ │
-│  └─────────────────┘  └─────────────────┘  └─────────────────────────────┘ │
-│                                                                             │
-│  HUMAN SIGN-OFF REQUIRED BEFORE ANY EXTERNAL ACTION (P2)                    │
-│                                                                             │
-└─────────────────────────────────────────────────────────────────────────────┘
-
-
-                    ┌─────────────────────────────┐
-                    │  AGENTIC HYPOTHESIS-TEST     │
-                    │  LOOP (inside each worker)   │
-                    │                              │
-                    │  ┌────────────────────────┐  │
-                    │  │ 1. Read source code     │  │
-                    │  └───────────┬────────────┘  │
-                    │              ▼                │
-                    │  ┌────────────────────────┐  │
-                    │  │ 2. Form hypothesis      │  │
-                    │  │    "integer overflow in  │  │
-                    │  │     image dimensions"    │  │
-                    │  └───────────┬────────────┘  │
-                    │              ▼                │
-                    │  ┌────────────────────────┐  │
-                    │  │ 3. Craft malformed input │  │
-                    │  │    (python3 script)      │  │
-                    │  └───────────┬────────────┘  │
-                    │              ▼                │
-                    │  ┌────────────────────────┐  │
-                    │  │ 4. Run ASAN binary      │  │
-                    │  │    with crafted input   │  │
-                    │  └───────────┬────────────┘  │
-                    │              ▼                │
-                    │  ┌────────────────────────┐  │
-                    │  │ 5. Read ASAN output     │──┼──► CRASH? → Report
-                    │  │    Did it crash?        │  │
-                    │  └───────────┬────────────┘  │
-                    │              │ No             │
-                    │              ▼                │
-                    │  ┌────────────────────────┐  │
-                    │  │ 6. Next hypothesis      │──┼──► Loop back to 2
-                    │  └────────────────────────┘  │
-                    │                              │
-                    └──────────────────────────────┘
+                           TARGET REPOSITORY
+                        (C/C++ open-source project)
+                                  |
+                                  v
+   +--------------------------------------------------------------+
+   |  STAGE 0 -- BUILD (one-time)                                  |
+   |                                                               |
+   |  Builder container: Clang + ASAN flags                        |
+   |  Auto-detects build system (configure / autotools / cmake /   |
+   |  Makefile), compiles with -fsanitize=address -g -O1           |
+   |  Collects binaries to host bin/ dir                           |
+   |                                                               |
+   |  Key files:                                                   |
+   |    harness/cli.py (_build_asan_binaries)                      |
+   |    worker/entrypoint.sh (build-system detection)              |
+   +-------------------------------+-------------------------------+
+                                   |  binaries mounted read-only
+                                   v
+   +--------------------------------------------------------------+
+   |  STAGE 1 -- FILE RANKING                                      |
+   |                                                               |
+   |  Default: Static regex ranker (free, instant, ~2-3s)          |
+   |  Alternative: LLM ranker (any litellm model)                  |
+   |                                                               |
+   |  Scores each source file 1-5 by vulnerability likelihood      |
+   |                                                               |
+   |  [parser.c]  [decode.c]  [alloc.c]  [utils.c]  [config.h]    |
+   |   score: 5    score: 5    score: 4    score: 2    score: 1    |
+   +-------------------------------+-------------------------------+
+                                   |  file scores
+                                   v
+   +--------------------------------------------------------------+
+   |  STAGE 2 -- JOB DISPATCH                                      |
+   |                                                               |
+   |  +----------+    +----------------------------------+         |
+   |  |  Redis   |<---| Orchestrator (Python asyncio)    |         |
+   |  | Priority |    |   * Semaphore (N parallel)       |         |
+   |  |  Queue   |    |   * Spend limit check per dequeue|         |
+   |  +----------+    |   * Timeout + SIGKILL on expiry  |         |
+   |                   +----------------------------------+         |
+   +------+----------+----------+----------+-------------------+---+
+          |          |          |          |
+          v          v          v          v
+   +-----------+ +-----------+ +-----------+ +-----------+
+   | WORKER    | | WORKER    | | WORKER    | | WORKER    |
+   | CONTAINER | | CONTAINER | | CONTAINER | | CONTAINER |
+   |           | |           | |           | |           |
+   | litellm   | | litellm   | | litellm   | | litellm   |
+   | ReAct     | | ReAct     | | ReAct     | | ReAct     |
+   | agent     | | agent     | | agent     | | agent     |
+   |           | |           | |           | |           |
+   | bash      | | bash      | | bash      | | bash      |
+   | read_file | | read_file | | read_file | | read_file |
+   | GDB/LLDB  | | GDB/LLDB  | | GDB/LLDB  | | GDB/LLDB  |
+   | ASAN bin  | | ASAN bin  | | ASAN bin  | | ASAN bin  |
+   |           | |           | |           | |           |
+   | Egress:   | | Egress:   | | Egress:   | | Egress:   |
+   | LLM API   | | LLM API   | | LLM API   | | LLM API   |
+   | only      | | only      | | only      | | only      |
+   +-----+-----+ +-----+-----+ +-----+-----+ +-----+-----+
+         |             |             |             |
+         +------+------+------+------+
+                |
+                v
+   +--------------------------------------------------------------+
+   |  STAGE 4 -- ASAN PARSER + TRIAGE                              |
+   |                                                               |
+   |  Extract crash metadata -> Assign severity tier -> Est. CVSS  |
+   |                                                               |
+   |  Tier 5: Control flow hijack (RIP/PC control)   CVSS 9.0-10  |
+   |  Tier 4: Arbitrary write (heap-buffer-overflow)  CVSS 7.5-9.0 |
+   |  Tier 3: Arbitrary read (use-after-free READ)    CVSS 5.0-7.5 |
+   |  Tier 2: Crash / DoS (null deref, stack overflow) CVSS 3.5-5  |
+   |  Tier 1: Memory leak only                        CVSS 1.0-3.5 |
+   +-------------------------------+-------------------------------+
+                                   |
+                                   v
+   +--------------------------------------------------------------+
+   |  STAGE 5 -- VALIDATION AGENT                                  |
+   |                                                               |
+   |  Separate LLM call per finding (litellm, provider-agnostic):  |
+   |  "Is the ASAN output real? Repro plausible? Meaningful?"      |
+   |                                                               |
+   |  +----------+    +--------------------+    +----------+       |
+   |  | VALIDATE |    | NEEDS_HUMAN_TRIAGE |    |  REJECT  |       |
+   |  | -> store |    | -> store (flagged) |    |  -> log  |       |
+   |  +----+-----+    +---------+----------+    +----+-----+       |
+   +-------+-----------------+--+--------------------+-------------+
+           |                 |                       |
+           v                 v                       v
+   +--------------------------------------------------------------+
+   |                                                               |
+   |  +----------------+ +----------------+ +-------------------+  |
+   |  | FINDINGS STORE | | AUDIT LOG      | | HUMAN REVIEW PKG  |  |
+   |  | (Postgres)     | | (JSONL)        | | (Markdown/finding)|  |
+   |  |                | |                | |                   |  |
+   |  | AES-256-GCM    | | SHA-3 hash     | | Description       |  |
+   |  |   encrypted    | |   chained      | | Reproduction      |  |
+   |  | Exploit code   | | Every action   | | ASAN output       |  |
+   |  |   never in     | |   logged BEFORE| | Candidate patch   |  |
+   |  |   plaintext    | |   execution    | | Reviewer sign-off |  |
+   |  +----------------+ +----------------+ +-------------------+  |
+   |                                                               |
+   |  HUMAN SIGN-OFF REQUIRED BEFORE ANY EXTERNAL ACTION (P2)     |
+   +--------------------------------------------------------------+
 ```
+
+---
+
+## Stage 0 -- Build (pre-compilation)
+
+**What it does**: Compiles the target project once with Clang and AddressSanitizer flags (`-fsanitize=address -g -O1 -fno-omit-frame-pointer`). The builder container auto-detects the build system (configure, autotools, cmake, or plain Makefile), applies optional `configure_flags` from config, and copies all resulting executables to a host directory.
+
+**Key files**:
+- `harness/cli.py` -- `_build_asan_binaries()` launches the builder container, `_BUILD_SCRIPT` is the in-container build logic
+- `worker/entrypoint.sh` -- fallback: if no pre-compiled binaries are mounted, the entrypoint compiles from source
+
+**Design decisions**:
+- **Build once, scan many**: Compilation takes minutes for large projects (e.g. FFmpeg). Building once and mounting the result read-only into every worker container eliminates this per-container overhead.
+- **Build-system auto-detection**: The builder tries configure, autotools (autoreconf), cmake, and Makefile in order. `configure_flags` in config allows project-specific build options (e.g. FFmpeg's `--extra-cflags`).
+- **Fallback compilation**: If no `--bin-dir` is supplied to `vuln-harness run`, the pipeline auto-builds before dispatch. If pre-compiled binaries are mounted into the worker, the entrypoint skips compilation entirely.
+
+---
+
+## Stage 1 -- File ranking
+
+**What it does**: Scores every C/C++ source file (`.c`, `.cpp`, `.h`, `.cc`, `.cxx`, `.hpp`) from 1 (lowest risk) to 5 (highest risk) based on vulnerability likelihood. Files are sorted by score descending and optionally capped by `max_files_to_scan`.
+
+**Key files**:
+- `harness/static_ranker.py` -- default static regex ranker
+- `harness/ranker.py` -- LLM-based ranker (alternative), routing logic, `RankedFile` dataclass, `_enumerate_source_files()`
+
+**Design decisions**:
+- **Static ranker as default** (`ranking_strategy: static`): Counts unsafe calls (`strcpy`, `sprintf`, `gets`, etc.), input sources (`fread`, `recv`, `fgets`), memory management (`malloc`, `free`, `mmap`), pointer arithmetic, and `memcpy`. Applies multipliers for source+sink combinations and memory+pointer combinations. Adds path-based bonuses for high-risk directory names (`parser`, `codec`, `decode`, `compress`, `crypt`) and penalties for test/doc/example directories. Runs in ~2-3 seconds on 3000+ files with zero API cost.
+- **LLM ranker as alternative** (`ranking_strategy: llm`): Sends file lists to any litellm model in batches of 100, asks for JSON-scored results. Useful when static heuristics are insufficient for a particular codebase.
+- **Normalization**: Raw scores are normalized to a 1-5 integer scale regardless of backend.
+
+---
+
+## Stage 2 -- Job dispatch
+
+**What it does**: Enqueues ranked files into a Redis sorted set (priority = vulnerability score), then dispatches Docker worker containers with concurrency controlled by an asyncio semaphore. Checks spend limits before each dequeue. Kills containers that exceed the configured timeout.
+
+**Key files**:
+- `harness/queue.py` -- `enqueue_jobs()`, `dequeue_job()` (ZPOPMAX for highest-priority-first), `get_run_spend()`, `increment_spend()`
+- `harness/dispatcher.py` -- `dispatch_run()` (semaphore loop), `_run_container()` (docker run command assembly)
+
+**Design decisions**:
+- **Priority queue**: Redis sorted sets with ZPOPMAX ensure the highest-scored files are processed first, so if a run is interrupted or hits a spend limit, the most promising files have already been scanned.
+- **Spend gating**: Before every dequeue, the dispatcher checks `get_run_spend()` against `max_run_spend_usd`. If the limit is reached, dispatch stops and logs a `spend_limit_reached` audit event.
+- **Timeout enforcement**: Each container gets `container_timeout_seconds` (default 1800s / 30 min). On timeout, the container is killed via `docker kill` and the job is marked `timeout`.
+
+---
+
+## Stage 3 -- Worker containers (ReAct agent loop)
+
+**What it does**: Each container receives one source file to analyze. The entrypoint renders a Jinja2 task prompt, copies source to a writable tmpfs, sets up the ASAN binary on PATH, and invokes the Python ReAct agent loop. The agent reads code, forms vulnerability hypotheses, crafts malformed inputs, runs the ASAN binary, and reads crash output. If it triggers a crash, it reports a structured JSON verdict to stdout.
+
+**Key files**:
+- `worker/agent/loop.py` -- `agent_loop()`: the core ReAct loop using `litellm.completion()` with tool_choice="auto"
+- `worker/agent/tools.py` -- two tools: `bash` (execute shell commands) and `read_file` (read file contents)
+- `worker/agent/run.py` -- entry point: reads env vars, loads prompts, calls `agent_loop()`, prints JSON verdict to stdout
+- `worker/prompts/worker-task.txt.j2` -- Jinja2 task prompt template
+- `worker/entrypoint.sh` -- container bootstrap (build detection, prompt rendering, agent invocation)
+- `worker/Dockerfile` -- Ubuntu 24.04 base, Clang, GDB, LLDB, Valgrind, Python 3, litellm
+
+**Design decisions**:
+- **Custom ReAct loop, not Claude Code**: The agent is a straightforward litellm completion loop with tool definitions. This makes it provider-agnostic (any model that supports tool use works) and keeps the dependency surface minimal.
+- **Two tools only**: `bash` (120s timeout per command) and `read_file`. The agent uses bash for everything: compiling inputs, running binaries, invoking GDB, inspecting ASAN output.
+- **Stdout reserved for verdict**: All build and status output goes to stderr. Only the final JSON verdict is printed to stdout, which the orchestrator parses.
+- **Token and cost tracking**: The loop tracks `prompt_tokens`, `completion_tokens`, and `response_cost` from litellm on every turn. These are included in the verdict metadata.
+
+---
+
+## Stage 4 -- ASAN parser and triage
+
+**What it does**: Parses agent JSON output and container stderr for AddressSanitizer crash signatures. Extracts vulnerability type, read/write direction, source location (function, file, line). Assigns a severity tier (1-5) and estimates CVSS based on the tier.
+
+**Key files**:
+- `harness/parser.py` -- `parse_result()`, severity/CVSS maps, ASAN regex patterns
+
+**Severity tiers**:
+
+| Tier | Condition | CVSS range |
+|------|-----------|------------|
+| 5 | Control flow hijack (RIP/PC control) | 9.0 - 10.0 |
+| 4 | Arbitrary write (heap-buffer-overflow WRITE, use-after-free WRITE) | 7.5 - 9.0 |
+| 3 | Arbitrary read (heap-buffer-overflow READ, use-after-free READ) | 5.0 - 7.5 |
+| 2 | Crash / DoS (null dereference, stack overflow) | 3.5 - 5.0 |
+| 1 | Memory leak only | 1.0 - 3.5 |
+
+**Design decisions**:
+- **Regex-based extraction**: ASAN output has a predictable format. Regex extraction is reliable and requires no LLM call.
+- **Conservative CVSS**: The estimate is the midpoint of the tier's range. Human reviewers must confirm or override (P7).
+
+---
+
+## Stage 5 -- Validation agent
+
+**What it does**: A separate LLM call reviews each finding and renders one of three verdicts: `VALIDATE`, `REJECT`, or `NEEDS_HUMAN_TRIAGE`. The prompt asks three specific questions: (1) is the ASAN output consistent with a real bug, (2) is the reproduction plausible, (3) is this a meaningful security issue.
+
+**Key files**:
+- `harness/validator.py` -- `validate_finding()`, `VALIDATION_PROMPT` template, `ValidationResult` dataclass
+
+**Design decisions**:
+- **Separate LLM call**: The validation model is independently configurable (`validation_model` in config). Using a separate call prevents the worker agent from self-validating its own findings.
+- **Provider-agnostic**: Uses the same `call_llm()` wrapper as all other LLM calls. Any litellm model works.
+- **Three verdicts**: VALIDATE (real, store and report), REJECT (log and discard), NEEDS_HUMAN_TRIAGE (store but flag for manual review).
+
+---
+
+## Container security model
+
+Every worker container is launched with the following security controls:
+
+```
+docker run --rm
+    --memory {worker_memory_gb}g          # Memory limit (default 4 GB)
+    --cpus {worker_cpus}                  # CPU limit (default 2)
+    --tmpfs /tmp:size=4g                  # Writable tmpfs for /tmp
+    -v {repo}:/target/src:ro              # Source mounted read-only
+    -v {bin}:/target/bin:ro               # Pre-compiled binaries read-only
+    --security-opt no-new-privileges      # No privilege escalation
+    --cap-drop ALL                        # Drop all Linux capabilities
+    {worker_image}
+```
+
+| Control | Implementation | Purpose |
+|---------|---------------|---------|
+| Non-root user | `USER researcher` (UID 1001) in Dockerfile | No root inside container |
+| All capabilities dropped | `--cap-drop ALL` | No privileged syscalls |
+| No privilege escalation | `--security-opt no-new-privileges` | Blocks setuid/setgid |
+| Read-only source mount | `-v {repo}:/target/src:ro` | Agent cannot modify source |
+| Read-only binary mount | `-v {bin}:/target/bin:ro` | Agent cannot modify binaries |
+| tmpfs workspace | `--tmpfs /tmp:size=4g` | Writable area is ephemeral and size-limited |
+| Memory limit | `--memory {worker_memory_gb}g` | Prevents OOM of host |
+| CPU limit | `--cpus {worker_cpus}` | Prevents CPU starvation |
+| Network egress allowlist | iptables on bridge network | Only LLM API endpoints reachable |
+| No inter-container comms | `enable_icc=false` on Docker bridge | Containers cannot talk to each other |
+| Ephemeral lifecycle | `--rm` flag, fresh per job | No state persists between runs |
+
+**Network isolation** (`scripts/setup-network.sh`): Creates a Docker bridge network with ICC disabled and iptables rules that allow egress only to:
+- `api.anthropic.com:443`
+- `api.openai.com:443`
+- `generativelanguage.googleapis.com:443`
+
+The allowed domains are configurable via `ALLOWED_API_DOMAINS` env var. All other egress is silently dropped. DNS is allowed for initial resolution only.
+
+---
+
+## Hypothesis-test loop (inside each worker)
+
+```
+                +-----------------------------+
+                |  AGENTIC HYPOTHESIS-TEST     |
+                |  LOOP (inside each worker)   |
+                |                              |
+                |  +------------------------+  |
+                |  | 1. Read source code     |  |
+                |  +----------+-------------+  |
+                |             v                |
+                |  +------------------------+  |
+                |  | 2. Form hypothesis      |  |
+                |  |    "integer overflow in  |  |
+                |  |     image dimensions"    |  |
+                |  +----------+-------------+  |
+                |             v                |
+                |  +------------------------+  |
+                |  | 3. Craft malformed input |  |
+                |  |    (python3 script)      |  |
+                |  +----------+-------------+  |
+                |             v                |
+                |  +------------------------+  |
+                |  | 4. Run ASAN binary      |  |
+                |  |    with crafted input   |  |
+                |  +----------+-------------+  |
+                |             v                |
+                |  +------------------------+  |
+                |  | 5. Read ASAN output     |--+--> CRASH? -> Report
+                |  |    Did it crash?        |  |
+                |  +----------+-------------+  |
+                |             | No             |
+                |             v                |
+                |  +------------------------+  |
+                |  | 6. Next hypothesis      |--+--> Loop back to 2
+                |  +------------------------+  |
+                |                              |
+                +------------------------------+
+```
+
+The agent has up to `max_turns_per_worker` (default 50) LLM turns. Each turn may invoke one or more tools (`bash`, `read_file`). The agent reports a JSON verdict with fields: `verdict`, `vuln_type`, `file`, `line`, `function`, `asan_output`, `reproduction`, `candidate_patch`, `confidence`, `reasoning`.
+
+---
+
+## Data flow
+
+```
+Source files  ->  Scores (1-5)  ->  Redis priority queue
+                                        |
+                          +-------------+
+                          v
+                    Worker containers
+                          |
+                    JSON verdict (stdout) + ASAN traces (stderr)
+                          |
+                          v
+                    Parsed findings (ParsedFinding)
+                          |
+                          v
+                    Validation verdicts (VALIDATE / REJECT / NEEDS_HUMAN_TRIAGE)
+                          |
+                   +------+------+
+                   |             |
+                   v             v
+            Encrypted        Markdown
+            Postgres         human-review
+            store            reports
+                   |
+                   v
+            Human review + sign-off (P2)
+```
+
+Each stage writes to the audit log before acting. The audit log is the system of record: JSONL format, SHA-3 hash-chained, tamper-evident, designed for governance platform ingestion.
+
+---
+
+## Cost tracking
+
+Spend is tracked at two levels:
+
+- **Per-run**: `max_run_spend_usd` (default $100). Before each job dequeue, the dispatcher reads `spend:{run_id}` from Redis. If the current spend meets or exceeds the limit, dispatch stops immediately and a `spend_limit_reached` event is logged.
+- **Per-day**: `max_day_spend_usd` (default $500). Provides a global safety net across multiple runs.
+
+The worker agent loop tracks cost internally via litellm's `response_cost` metadata on each completion call. Token counts (`input_tokens`, `output_tokens`) and cost are included in every `llm_call` audit entry from both the orchestrator (ranking, validation) and workers.
+
+All LLM calls are also logged to the audit trail with model name, token counts, and cost, providing a complete cost breakdown per stage. The CLI command `vuln-harness cost --run-id <uuid>` parses the audit log and prints a per-stage cost summary.
+
+---
+
+## Audit and encryption
+
+**Audit log** (`harness/audit.py`): Append-only JSONL, one entry per action. Each entry includes a SHA-3 hash of its contents and the hash of the previous entry, forming a tamper-evident chain. Writes are synchronous with file locking (`fcntl.LOCK_EX`). If a write fails, the run fails (P3). Chain integrity is verifiable via `vuln-harness audit-verify`.
+
+**Findings encryption** (`harness/crypto.py`): Reproduction steps, candidate patches, and ASAN output are encrypted with AES-256-GCM before storage in Postgres. The encryption key is loaded from the `FINDINGS_ENC_KEY` environment variable (base64-encoded, 32-byte key). Exploit code is never stored in plaintext (P8).
+
+---
+
+## Key file reference
+
+| Component | Path | Purpose |
+|-----------|------|---------|
+| CLI | `harness/cli.py` | Commands: `run`, `build`, `rank`, `review`, `approve`, `audit-verify`, `cost` |
+| Config | `harness/config.py` | Pydantic-settings model, YAML + env var loading |
+| Static ranker | `harness/static_ranker.py` | Default file ranker (regex, free) |
+| LLM ranker | `harness/ranker.py` | Alternative file ranker (litellm) |
+| Queue | `harness/queue.py` | Redis sorted set job queue |
+| Dispatcher | `harness/dispatcher.py` | Container launch, concurrency, timeout |
+| Parser | `harness/parser.py` | ASAN output parsing, severity tiers |
+| Validator | `harness/validator.py` | LLM-based finding validation |
+| Findings store | `harness/findings.py` | Postgres storage, report generation |
+| Audit log | `harness/audit.py` | SHA-3 hash-chained JSONL |
+| Encryption | `harness/crypto.py` | AES-256-GCM for findings at rest |
+| Agent loop | `worker/agent/loop.py` | ReAct loop via litellm |
+| Agent tools | `worker/agent/tools.py` | bash, read_file tool implementations |
+| Agent entry | `worker/agent/run.py` | Worker container entry point |
+| Task prompt | `worker/prompts/worker-task.txt.j2` | Jinja2 prompt template |
+| Dockerfile | `worker/Dockerfile` | Worker image (Ubuntu 24.04, Clang, GDB) |
+| Entrypoint | `worker/entrypoint.sh` | Build detection, ASAN compile, agent invoke |
+| Network setup | `scripts/setup-network.sh` | iptables egress allowlist |
+| Constitution | `01-constitution.md` | P1-P8 non-negotiable principles |

--- a/architecture.md
+++ b/architecture.md
@@ -10,6 +10,12 @@ All LLM calls route through litellm, making the system provider-agnostic. The de
 
 ---
 
+<p align="center">
+  <img src="docs/architecture.svg" alt="Mantis pipeline architecture" width="900"/>
+</p>
+
+---
+
 ## Pipeline diagram
 
 ```

--- a/docs/architecture.svg
+++ b/docs/architecture.svg
@@ -24,7 +24,7 @@
 
   <rect x="220" y="122" width="460" height="78" rx="8" fill="#fefce8" stroke="#ca8a04" stroke-width="1.5"/>
   <text x="450" y="143" text-anchor="middle" font-weight="bold" fill="#854d0e" font-size="11">STAGE 0 — BUILD (one-time)</text>
-  <text x="450" y="161" text-anchor="middle" font-weight="bold" fill="#1e3a5f">Builder container compiles ASAN binaries once</text>
+  <text x="450" y="161" text-anchor="middle" font-weight="bold" fill="#1e3a5f">Builder container compiles configured sanitizer binaries once</text>
   <text x="450" y="178" text-anchor="middle" fill="#475569" font-size="11">Clang + sanitizers, build-system auto-detection, binaries mounted read-only</text>
   <text x="450" y="193" text-anchor="middle" fill="#475569" font-size="11">Key files: `harness/cli.py`, `worker/entrypoint.sh`</text>
 
@@ -70,7 +70,7 @@
   <rect x="290" y="474" width="160" height="64" rx="6" fill="#ffffff" stroke="#86efac" stroke-width="1"/>
   <text x="370" y="493" text-anchor="middle" font-weight="bold" fill="#1e3a5f" font-size="11">Worker 2</text>
   <text x="370" y="509" text-anchor="middle" fill="#475569" font-size="10">Read code → hypothesize</text>
-  <text x="370" y="523" text-anchor="middle" fill="#475569" font-size="10">Craft input → run ASAN binary</text>
+  <text x="370" y="523" text-anchor="middle" fill="#475569" font-size="10">Craft input → run instrumented binary</text>
 
   <rect x="470" y="474" width="160" height="64" rx="6" fill="#ffffff" stroke="#86efac" stroke-width="1"/>
   <text x="550" y="493" text-anchor="middle" font-weight="bold" fill="#1e3a5f" font-size="11">Worker 3</text>
@@ -84,8 +84,8 @@
   <line x1="450" y1="556" x2="450" y2="576" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow)"/>
 
   <rect x="120" y="580" width="210" height="52" rx="8" fill="#eff6ff" stroke="#3b82f6" stroke-width="1.5"/>
-  <text x="225" y="600" text-anchor="middle" font-weight="bold" fill="#1e40af" font-size="11">STAGE 4 — ASAN PARSER + TRIAGE</text>
-  <text x="225" y="617" text-anchor="middle" fill="#475569" font-size="11">Extract vuln type, location, severity tier, CVSS estimate</text>
+  <text x="225" y="600" text-anchor="middle" font-weight="bold" fill="#1e40af" font-size="11">STAGE 4 — SANITIZER PARSER + TRIAGE</text>
+  <text x="225" y="617" text-anchor="middle" fill="#475569" font-size="11">Extract finding type, location, severity tier, CVSS estimate</text>
 
   <line x1="330" y1="606" x2="366" y2="606" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow)"/>
 

--- a/docs/architecture.svg
+++ b/docs/architecture.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 520" font-family="system-ui, -apple-system, sans-serif" font-size="13">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 640" font-family="system-ui, -apple-system, sans-serif" font-size="13">
   <defs>
     <marker id="arrow" viewBox="0 0 10 7" refX="10" refY="3.5" markerWidth="10" markerHeight="7" orient="auto-start-auto">
       <polygon points="0 0, 10 3.5, 0 7" fill="#64748b"/>
@@ -12,113 +12,98 @@
     </linearGradient>
   </defs>
 
-  <!-- Background -->
-  <rect width="900" height="520" rx="12" fill="url(#bg)" stroke="#e2e8f0" stroke-width="1"/>
+  <rect width="900" height="640" rx="12" fill="url(#bg)" stroke="#e2e8f0" stroke-width="1"/>
 
-  <!-- Title -->
-  <text x="450" y="32" text-anchor="middle" font-size="16" font-weight="bold" fill="#0f172a">Mantis — Five-Stage Vulnerability Discovery Pipeline</text>
+  <text x="450" y="30" text-anchor="middle" font-size="16" font-weight="bold" fill="#0f172a">Mantis — Stage 0-5 Vulnerability Discovery Pipeline</text>
 
-  <!-- Stage 1: File Ranking -->
-  <rect x="30" y="60" width="160" height="80" rx="8" fill="#eff6ff" stroke="#3b82f6" stroke-width="1.5"/>
-  <text x="110" y="82" text-anchor="middle" font-weight="bold" fill="#1e40af" font-size="11">STAGE 1</text>
-  <text x="110" y="100" text-anchor="middle" font-weight="bold" fill="#1e3a5f">File Ranking</text>
-  <text x="110" y="118" text-anchor="middle" fill="#475569" font-size="11">Static regex (default)</text>
-  <text x="110" y="132" text-anchor="middle" fill="#475569" font-size="11">or LLM via litellm</text>
+  <rect x="305" y="48" width="290" height="48" rx="8" fill="#ffffff" stroke="#94a3b8" stroke-width="1.2"/>
+  <text x="450" y="68" text-anchor="middle" font-weight="bold" fill="#0f172a">Target Repository</text>
+  <text x="450" y="85" text-anchor="middle" fill="#475569" font-size="11">Open-source C/C++ project source tree</text>
 
-  <!-- Arrow 1→Build -->
-  <line x1="190" y1="100" x2="218" y2="100" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <line x1="450" y1="96" x2="450" y2="118" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow)"/>
 
-  <!-- Auto-Build -->
-  <rect x="220" y="60" width="150" height="80" rx="8" fill="#fefce8" stroke="#ca8a04" stroke-width="1.5"/>
-  <text x="295" y="82" text-anchor="middle" font-weight="bold" fill="#854d0e" font-size="11">AUTO-BUILD</text>
-  <text x="295" y="100" text-anchor="middle" font-weight="bold" fill="#1e3a5f">ASAN Compile</text>
-  <text x="295" y="118" text-anchor="middle" fill="#475569" font-size="11">clang + sanitizers</text>
-  <text x="295" y="132" text-anchor="middle" fill="#475569" font-size="11">build once, reuse</text>
+  <rect x="220" y="122" width="460" height="78" rx="8" fill="#fefce8" stroke="#ca8a04" stroke-width="1.5"/>
+  <text x="450" y="143" text-anchor="middle" font-weight="bold" fill="#854d0e" font-size="11">STAGE 0 — BUILD (one-time)</text>
+  <text x="450" y="161" text-anchor="middle" font-weight="bold" fill="#1e3a5f">Builder container compiles ASAN binaries once</text>
+  <text x="450" y="178" text-anchor="middle" fill="#475569" font-size="11">Clang + sanitizers, build-system auto-detection, binaries mounted read-only</text>
+  <text x="450" y="193" text-anchor="middle" fill="#475569" font-size="11">Key files: `harness/cli.py`, `worker/entrypoint.sh`</text>
 
-  <!-- Arrow Build→Queue -->
-  <line x1="370" y1="100" x2="398" y2="100" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <line x1="450" y1="200" x2="450" y2="222" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow)"/>
 
-  <!-- Stage 2: Job Queue -->
-  <rect x="400" y="60" width="140" height="80" rx="8" fill="#eff6ff" stroke="#3b82f6" stroke-width="1.5"/>
-  <text x="470" y="82" text-anchor="middle" font-weight="bold" fill="#1e40af" font-size="11">STAGE 2</text>
-  <text x="470" y="100" text-anchor="middle" font-weight="bold" fill="#1e3a5f">Job Queue</text>
-  <text x="470" y="118" text-anchor="middle" fill="#475569" font-size="11">Redis sorted set</text>
-  <text x="470" y="132" text-anchor="middle" fill="#475569" font-size="11">priority by score</text>
+  <rect x="220" y="226" width="460" height="76" rx="8" fill="#eff6ff" stroke="#3b82f6" stroke-width="1.5"/>
+  <text x="450" y="247" text-anchor="middle" font-weight="bold" fill="#1e40af" font-size="11">STAGE 1 — FILE RANKING</text>
+  <text x="450" y="265" text-anchor="middle" font-weight="bold" fill="#1e3a5f">Static regex ranker by default, LLM ranker optional</text>
+  <text x="450" y="282" text-anchor="middle" fill="#475569" font-size="11">Scores source files 1-5 by vulnerability likelihood and selects scan order</text>
+  <text x="450" y="297" text-anchor="middle" fill="#475569" font-size="11">Key files: `harness/static_ranker.py`, `harness/ranker.py`</text>
 
-  <!-- Arrow Queue→Workers -->
-  <line x1="470" y1="140" x2="470" y2="175" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <line x1="450" y1="302" x2="450" y2="324" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow)"/>
 
-  <!-- Stage 3: Worker Containers (larger box) -->
-  <rect x="100" y="180" width="740" height="130" rx="8" fill="#f0fdf4" stroke="#16a34a" stroke-width="1.5"/>
-  <text x="470" y="200" text-anchor="middle" font-weight="bold" fill="#166534" font-size="11">STAGE 3 — PARALLEL WORKER CONTAINERS (Docker, isolated)</text>
+  <rect x="80" y="328" width="220" height="82" rx="8" fill="#eff6ff" stroke="#3b82f6" stroke-width="1.5"/>
+  <text x="190" y="349" text-anchor="middle" font-weight="bold" fill="#1e40af" font-size="11">STAGE 2 — JOB QUEUE</text>
+  <text x="190" y="368" text-anchor="middle" font-weight="bold" fill="#1e3a5f">Redis priority queue</text>
+  <text x="190" y="385" text-anchor="middle" fill="#475569" font-size="11">Sorted set ordered by vulnerability score</text>
+  <text x="190" y="400" text-anchor="middle" fill="#475569" font-size="11">Highest-risk files dequeue first</text>
 
-  <!-- Worker 1 -->
-  <rect x="120" y="215" width="165" height="80" rx="6" fill="white" stroke="#86efac" stroke-width="1"/>
-  <text x="202" y="235" text-anchor="middle" font-weight="bold" fill="#1e3a5f" font-size="11">Worker 1</text>
-  <text x="202" y="252" text-anchor="middle" fill="#475569" font-size="10">litellm ReAct loop</text>
-  <text x="202" y="266" text-anchor="middle" fill="#475569" font-size="10">Read code → Hypothesize</text>
-  <text x="202" y="280" text-anchor="middle" fill="#475569" font-size="10">→ Craft input → Run ASAN</text>
+  <rect x="340" y="328" width="220" height="82" rx="8" fill="#eefdf6" stroke="#10b981" stroke-width="1.5"/>
+  <text x="450" y="349" text-anchor="middle" font-weight="bold" fill="#047857" font-size="11">DISPATCHER / ORCHESTRATOR</text>
+  <text x="450" y="368" text-anchor="middle" font-weight="bold" fill="#1e3a5f">Python asyncio control plane</text>
+  <text x="450" y="385" text-anchor="middle" fill="#475569" font-size="11">Semaphore, spend-limit checks, timeout + SIGKILL</text>
+  <text x="450" y="400" text-anchor="middle" fill="#475569" font-size="11">Key files: `harness/queue.py`, `harness/dispatcher.py`</text>
 
-  <!-- Worker 2 -->
-  <rect x="300" y="215" width="165" height="80" rx="6" fill="white" stroke="#86efac" stroke-width="1"/>
-  <text x="382" y="235" text-anchor="middle" font-weight="bold" fill="#1e3a5f" font-size="11">Worker 2</text>
-  <text x="382" y="252" text-anchor="middle" fill="#475569" font-size="10">litellm ReAct loop</text>
-  <text x="382" y="266" text-anchor="middle" fill="#475569" font-size="10">Read code → Hypothesize</text>
-  <text x="382" y="280" text-anchor="middle" fill="#475569" font-size="10">→ Craft input → Run ASAN</text>
+  <rect x="600" y="328" width="220" height="82" rx="8" fill="#f8fafc" stroke="#cbd5e1" stroke-width="1.2" stroke-dasharray="4,3"/>
+  <text x="710" y="349" text-anchor="middle" font-weight="bold" fill="#64748b" font-size="11">LLM PROVIDERS</text>
+  <text x="710" y="368" text-anchor="middle" fill="#475569" font-size="11">via litellm</text>
+  <text x="710" y="385" text-anchor="middle" fill="#475569" font-size="10">Anthropic / OpenAI / Google</text>
+  <text x="710" y="400" text-anchor="middle" fill="#475569" font-size="10">Ollama / other compatible backends</text>
 
-  <!-- Worker N -->
-  <rect x="490" y="215" width="165" height="80" rx="6" fill="white" stroke="#86efac" stroke-width="1"/>
-  <text x="572" y="235" text-anchor="middle" font-weight="bold" fill="#1e3a5f" font-size="11">Worker 3</text>
-  <text x="572" y="252" text-anchor="middle" fill="#475569" font-size="10">litellm ReAct loop</text>
-  <text x="572" y="266" text-anchor="middle" fill="#475569" font-size="10">Read code → Hypothesize</text>
-  <text x="572" y="280" text-anchor="middle" fill="#475569" font-size="10">→ Craft input → Run ASAN</text>
+  <line x1="300" y1="369" x2="340" y2="369" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <line x1="450" y1="410" x2="450" y2="432" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow)"/>
 
-  <!-- Worker ... -->
-  <rect x="670" y="215" width="150" height="80" rx="6" fill="white" stroke="#86efac" stroke-width="1" stroke-dasharray="4,3"/>
-  <text x="745" y="260" text-anchor="middle" fill="#94a3b8" font-size="12">Worker N...</text>
+  <rect x="85" y="438" width="730" height="118" rx="8" fill="#f0fdf4" stroke="#16a34a" stroke-width="1.5"/>
+  <text x="450" y="458" text-anchor="middle" font-weight="bold" fill="#166534" font-size="11">STAGE 3 — PARALLEL WORKER CONTAINERS</text>
 
-  <!-- Arrow Workers→Parser -->
-  <line x1="470" y1="310" x2="470" y2="345" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <rect x="110" y="474" width="160" height="64" rx="6" fill="#ffffff" stroke="#86efac" stroke-width="1"/>
+  <text x="190" y="493" text-anchor="middle" font-weight="bold" fill="#1e3a5f" font-size="11">Worker 1</text>
+  <text x="190" y="509" text-anchor="middle" fill="#475569" font-size="10">litellm ReAct agent</text>
+  <text x="190" y="523" text-anchor="middle" fill="#475569" font-size="10">`bash`, `read_file` tools</text>
 
-  <!-- Stage 4: ASAN Parser -->
-  <rect x="250" y="350" width="200" height="70" rx="8" fill="#eff6ff" stroke="#3b82f6" stroke-width="1.5"/>
-  <text x="350" y="372" text-anchor="middle" font-weight="bold" fill="#1e40af" font-size="11">STAGE 4</text>
-  <text x="350" y="390" text-anchor="middle" font-weight="bold" fill="#1e3a5f">ASAN Parser + Triage</text>
-  <text x="350" y="407" text-anchor="middle" fill="#475569" font-size="11">Severity tier 1-5, CVSS estimate</text>
+  <rect x="290" y="474" width="160" height="64" rx="6" fill="#ffffff" stroke="#86efac" stroke-width="1"/>
+  <text x="370" y="493" text-anchor="middle" font-weight="bold" fill="#1e3a5f" font-size="11">Worker 2</text>
+  <text x="370" y="509" text-anchor="middle" fill="#475569" font-size="10">Read code → hypothesize</text>
+  <text x="370" y="523" text-anchor="middle" fill="#475569" font-size="10">Craft input → run ASAN binary</text>
 
-  <!-- Arrow Parser→Validator -->
-  <line x1="450" y1="385" x2="488" y2="385" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <rect x="470" y="474" width="160" height="64" rx="6" fill="#ffffff" stroke="#86efac" stroke-width="1"/>
+  <text x="550" y="493" text-anchor="middle" font-weight="bold" fill="#1e3a5f" font-size="11">Worker 3</text>
+  <text x="550" y="509" text-anchor="middle" fill="#475569" font-size="10">JSON verdict on stdout</text>
+  <text x="550" y="523" text-anchor="middle" fill="#475569" font-size="10">ASAN traces on stderr</text>
 
-  <!-- Stage 5: Validation -->
-  <rect x="490" y="350" width="200" height="70" rx="8" fill="#fdf2f8" stroke="#db2777" stroke-width="1.5"/>
-  <text x="590" y="372" text-anchor="middle" font-weight="bold" fill="#9d174d" font-size="11">STAGE 5</text>
-  <text x="590" y="390" text-anchor="middle" font-weight="bold" fill="#1e3a5f">Validation Agent</text>
-  <text x="590" y="407" text-anchor="middle" fill="#475569" font-size="11">LLM filters false positives</text>
+  <rect x="650" y="474" width="140" height="64" rx="6" fill="#ffffff" stroke="#86efac" stroke-width="1" stroke-dasharray="4,3"/>
+  <text x="720" y="505" text-anchor="middle" fill="#94a3b8" font-size="12">Worker N...</text>
 
-  <!-- Arrow Validator→Outputs -->
-  <line x1="470" y1="420" x2="470" y2="450" stroke="#16a34a" stroke-width="1.5" marker-end="url(#arrow-green)"/>
+  <line x1="710" y1="410" x2="710" y2="438" stroke="#64748b" stroke-width="1.2" marker-end="url(#arrow)"/>
+  <line x1="450" y1="556" x2="450" y2="576" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow)"/>
 
-  <!-- Outputs row -->
-  <rect x="100" y="455" width="170" height="45" rx="6" fill="#faf5ff" stroke="#9333ea" stroke-width="1"/>
-  <text x="185" y="475" text-anchor="middle" font-weight="bold" fill="#7e22ce" font-size="11">Findings (Markdown)</text>
-  <text x="185" y="490" text-anchor="middle" fill="#475569" font-size="10">runs/{id}/findings/*.md</text>
+  <rect x="120" y="580" width="210" height="52" rx="8" fill="#eff6ff" stroke="#3b82f6" stroke-width="1.5"/>
+  <text x="225" y="600" text-anchor="middle" font-weight="bold" fill="#1e40af" font-size="11">STAGE 4 — ASAN PARSER + TRIAGE</text>
+  <text x="225" y="617" text-anchor="middle" fill="#475569" font-size="11">Extract vuln type, location, severity tier, CVSS estimate</text>
 
-  <rect x="290" y="455" width="170" height="45" rx="6" fill="#faf5ff" stroke="#9333ea" stroke-width="1"/>
-  <text x="375" y="475" text-anchor="middle" font-weight="bold" fill="#7e22ce" font-size="11">Encrypted Postgres</text>
-  <text x="375" y="490" text-anchor="middle" fill="#475569" font-size="10">AES-256-GCM at rest</text>
+  <line x1="330" y1="606" x2="366" y2="606" stroke="#64748b" stroke-width="1.5" marker-end="url(#arrow)"/>
 
-  <rect x="480" y="455" width="170" height="45" rx="6" fill="#faf5ff" stroke="#9333ea" stroke-width="1"/>
-  <text x="565" y="475" text-anchor="middle" font-weight="bold" fill="#7e22ce" font-size="11">Audit Log</text>
-  <text x="565" y="490" text-anchor="middle" fill="#475569" font-size="10">SHA-3 hash-chained JSONL</text>
+  <rect x="370" y="580" width="210" height="52" rx="8" fill="#fdf2f8" stroke="#db2777" stroke-width="1.5"/>
+  <text x="475" y="600" text-anchor="middle" font-weight="bold" fill="#9d174d" font-size="11">STAGE 5 — VALIDATION AGENT</text>
+  <text x="475" y="617" text-anchor="middle" fill="#475569" font-size="11">Separate provider-agnostic LLM call: VALIDATE / REJECT / NEEDS TRIAGE</text>
 
-  <rect x="670" y="455" width="170" height="45" rx="6" fill="#fff7ed" stroke="#ea580c" stroke-width="1"/>
-  <text x="755" y="475" text-anchor="middle" font-weight="bold" fill="#c2410c" font-size="11">Human Review</text>
-  <text x="755" y="490" text-anchor="middle" fill="#475569" font-size="10">Required before disclosure</text>
+  <line x1="580" y1="606" x2="616" y2="606" stroke="#16a34a" stroke-width="1.5" marker-end="url(#arrow-green)"/>
 
-  <!-- LLM Provider label -->
-  <rect x="720" y="60" width="150" height="80" rx="8" fill="#f8fafc" stroke="#cbd5e1" stroke-width="1" stroke-dasharray="4,3"/>
-  <text x="795" y="82" text-anchor="middle" font-weight="bold" fill="#64748b" font-size="11">LLM PROVIDER</text>
-  <text x="795" y="100" text-anchor="middle" fill="#475569" font-size="11">via litellm</text>
-  <text x="795" y="118" text-anchor="middle" fill="#475569" font-size="10">Anthropic / OpenAI</text>
-  <text x="795" y="132" text-anchor="middle" fill="#475569" font-size="10">Google / Ollama / ...</text>
+  <rect x="620" y="568" width="118" height="30" rx="6" fill="#faf5ff" stroke="#9333ea" stroke-width="1"/>
+  <text x="679" y="587" text-anchor="middle" font-weight="bold" fill="#7e22ce" font-size="11">Markdown reports</text>
+
+  <rect x="750" y="568" width="118" height="30" rx="6" fill="#faf5ff" stroke="#9333ea" stroke-width="1"/>
+  <text x="809" y="587" text-anchor="middle" font-weight="bold" fill="#7e22ce" font-size="11">Encrypted Postgres</text>
+
+  <rect x="620" y="604" width="118" height="30" rx="6" fill="#faf5ff" stroke="#9333ea" stroke-width="1"/>
+  <text x="679" y="623" text-anchor="middle" font-weight="bold" fill="#7e22ce" font-size="11">SHA-3 audit log</text>
+
+  <rect x="750" y="604" width="118" height="30" rx="6" fill="#fff7ed" stroke="#ea580c" stroke-width="1"/>
+  <text x="809" y="623" text-anchor="middle" font-weight="bold" fill="#c2410c" font-size="11">Human review gate</text>
 </svg>


### PR DESCRIPTION
## Summary

- Rewrites `architecture.md` from scratch to match the actual codebase implementation
- Fixes all inaccuracies identified in #21: Claude Code references replaced with litellm ReAct agent, Anthropic-only egress replaced with configurable allowlist, static regex ranker documented as default
- Adds prose overview, per-stage component descriptions with key file references, container security model table, data flow section, cost tracking section, and full file reference table
- Retains the hypothesis-test loop diagram (it was accurate) and keeps ASCII art style for terminal/GitHub readability

## Inaccuracies fixed

1. Stage 1: "Claude Code / Anthropic API" -> static regex ranker (default) or LLM ranker via litellm
2. Stage 3: "Claude Code (headless)" -> litellm ReAct agent loop (`worker/agent/loop.py`)
3. Egress: "api.anthropic.com:443 ONLY" -> three configurable providers (Anthropic, OpenAI, Google) via `ALLOWED_API_DOMAINS`
4. Stage 5: "Separate Claude instance" -> separate LLM call (provider-agnostic via litellm)
5. Added: build-once-scan-many pre-compilation pattern (Stage 0)
6. Added: static ranker as default with detailed signal descriptions
7. Added: container security controls table (--cap-drop ALL, --read-only mounts, no-new-privileges, tmpfs, non-root UID 1001)
8. Added: cost tracking flow (Redis spend tracking, per-run/per-day limits, hard-stop)
9. Added: prose overview instead of code-block-only format

## Test plan

- [ ] Verify every file path in the document exists in the repo
- [ ] Verify every claim against the actual source code (all files listed in #21 were read before writing)
- [ ] Confirm the document renders correctly on GitHub (ASCII art alignment, tables, headers)
- [ ] Check that the document serves all three audiences: new contributors, CISO/security reviewers, system understanding

Closes #21

Generated with [Claude Code](https://claude.com/claude-code)