### PR TITLE
Add NIST compliance & security documentation

### DIFF
--- a/docs/compliance/data-retention-policy.md
+++ b/docs/compliance/data-retention-policy.md
@@ -1,0 +1,240 @@
+# Mantis Data Retention & Destruction Policy
+
+**Document version**: 1.0
+**Last updated**: 2026-04-25
+**Applicable system**: Mantis Autonomous Vulnerability Discovery Harness
+**Policy owner**: Security Operations
+
+---
+
+## 1. Scope
+
+This policy governs the retention, protection, and destruction of all data created, processed, or stored by the Mantis autonomous vulnerability discovery harness. It applies to:
+
+- All data stored in the Postgres findings database
+- Audit log files (JSONL)
+- Worker container artifacts (ephemeral)
+- Configuration and secret material
+- Human review reports (markdown)
+- Redis queue data
+
+This policy is designed to satisfy requirements from NIST CSF 2.0 (PR.DS, ID.AM), FINRA record retention rules, SOX Section 802, and GDPR/CCPA data minimization principles.
+
+---
+
+## 2. Data Classification
+
+| Data Type | Classification | Storage Location | Encryption | Integrity Mechanism | Retention Period |
+|-----------|---------------|-----------------|------------|---------------------|-----------------|
+| Audit log entries | Compliance | JSONL file at `{run_dir}/audit.jsonl` | None (plaintext) | SHA-3 hash chain (`harness/audit.py:81-83`) | 7 years minimum |
+| Run metadata | Internal | Postgres `runs` table | None (plaintext) | Database constraints | 3 years |
+| Job metadata | Internal | Postgres `jobs` table | None (plaintext) | Database constraints, foreign key to `runs` | 3 years |
+| Finding metadata (vuln_type, severity, file, line) | Internal | Postgres `findings` table | None (plaintext) | Database constraints, foreign keys | 3 years or 1 year post-disclosure, whichever is later |
+| Reproduction commands (PoC) | Restricted | Postgres `reproduction_enc` column | AES-256-GCM (`harness/crypto.py:13-18`) | GCM authentication tag | 3 years or 1 year post-disclosure |
+| Candidate patches | Restricted | Postgres `patch_enc` column | AES-256-GCM | GCM authentication tag | 3 years or 1 year post-disclosure |
+| ASAN crash output | Restricted | Postgres `asan_output_enc` column | AES-256-GCM | GCM authentication tag | 3 years or 1 year post-disclosure |
+| Raw agent output | Sensitive | Postgres `jobs.result_raw` JSONB column | None (plaintext -- gap, see note) | Database constraints | 3 years |
+| Worker container artifacts | Ephemeral | tmpfs inside container | None | Destroyed on container exit | Duration of container run only |
+| Human review reports | Internal | `{run_dir}/findings/{finding_id}.md` | None (plaintext) | Filesystem permissions | 3 years or 1 year post-disclosure |
+| API keys | Secret | Environment variables only | N/A (in-memory) | Never persisted (P4) | Session-scoped |
+| Encryption key (FINDINGS_ENC_KEY) | Critical | Environment variable | N/A (in-memory) | Base64-encoded, 32-byte validation (`harness/crypto.py:35-37`) | Rotated per key management policy |
+| Redis queue data | Transient | Redis in-memory | None | Spend limit checks (`harness/dispatcher.py:234-246`) | Duration of scan run + 24 hours |
+| Configuration (harness.yaml) | Internal | Filesystem | None | Version control (git) | Indefinite (version-controlled) |
+
+**Note on raw agent output**: The `jobs.result_raw` JSONB column may contain ASAN output, vulnerability descriptions, and reproduction commands in plaintext. This is a known gap. It should be encrypted or access-restricted in production (see threat model R7).
+
+---
+
+## 3. Retention Periods
+
+### 3.1 Compliance Records (7-year retention)
+
+**Audit log files** must be retained for a minimum of 7 years to satisfy:
+- FINRA Rule 4511: 6-year retention for business records
+- SOX Section 802: 7-year retention for audit workpapers
+- NIST CSF 2.0 PR.PS-04: Log record availability
+
+The SHA-3 hash chain (`harness/audit.py:93-123`) provides tamper-evident integrity verification throughout the retention period. Audit logs should be archived to immutable storage (S3 with Object Lock, Azure Immutable Blob, or equivalent) within 24 hours of run completion.
+
+### 3.2 Finding Records (3 years or 1 year post-disclosure)
+
+**Finding metadata, encrypted exploit data, and associated job/run records** are retained for 3 years from discovery, or 1 year after public disclosure, whichever is later.
+
+This satisfies:
+- Regulatory audit requirements for vulnerability management programs
+- Legal hold requirements for ongoing coordinated disclosure
+- Evidence preservation for potential litigation
+
+### 3.3 Ephemeral Data (destroyed on container exit)
+
+**Worker container artifacts** exist only for the duration of the container run and are automatically destroyed:
+- tmpfs at `/workspace` and `/tmp` cleared on container removal (`harness/dispatcher.py:34`, `--rm` flag)
+- Container filesystem is read-only; writable areas are tmpfs only
+- No data persists between container runs (P5, `01-constitution.md:32-33`)
+
+### 3.4 Transient Queue Data (run duration + 24 hours)
+
+**Redis queue entries** for job status and spend tracking are retained for the duration of the scan run plus 24 hours for operational review. After that period, Redis keys should be expired or explicitly deleted.
+
+### 3.5 Secret Material (session-scoped)
+
+**API keys and encryption keys** exist only in process memory via environment variables. They are:
+- Never written to disk (P4, `01-constitution.md:29`)
+- Never included in Docker images
+- Never logged in the audit log
+- Destroyed when the process exits
+
+---
+
+## 4. Destruction Procedures
+
+### 4.1 Cryptographic Erasure
+
+For data encrypted with AES-256-GCM (reproduction commands, patches, ASAN output in the `findings` table):
+
+**Cryptographic erasure** is the primary destruction method. When the `FINDINGS_ENC_KEY` is destroyed, all data encrypted with that key becomes permanently unreadable.
+
+Procedure:
+1. Verify all active legal holds and retention obligations have been satisfied
+2. Confirm no pending coordinated disclosures reference the affected findings
+3. Revoke and destroy the `FINDINGS_ENC_KEY` from the secrets manager
+4. Overwrite the key material in all backup locations
+5. Record the key destruction event in the audit log with operator identity
+6. Retain the audit log entry recording the destruction (7-year retention)
+
+For individual finding destruction:
+1. Execute `DELETE FROM findings WHERE finding_id = $1` to remove encrypted columns
+2. Record the deletion in the audit log with justification and operator identity
+3. The encrypted data is unrecoverable once the database row is deleted
+
+### 4.2 Audit Log Archival
+
+Audit logs must be archived before destruction of associated findings:
+
+Procedure:
+1. Verify hash chain integrity: run `verify_chain()` (`harness/audit.py:93-123`)
+2. Copy the audit JSONL file to immutable archival storage
+3. Verify the archived copy by re-running hash chain verification on the archive
+4. Record the archival event (archive location, hash of final entry, entry count)
+5. The original file may be removed from operational storage after archival confirmation
+
+### 4.3 Database Record Destruction
+
+For non-encrypted database records (runs, jobs, finding metadata):
+
+Procedure:
+1. Identify all records past their retention period
+2. Verify no audit log entries reference the records that have not been archived
+3. Execute deletion in dependency order: `findings` -> `jobs` -> `runs`
+4. Record the bulk deletion in the audit log (run_ids deleted, count, operator, justification)
+5. Run `VACUUM` on affected tables to reclaim storage
+
+### 4.4 Redis Data Destruction
+
+Redis queue data is transient by design:
+
+Procedure:
+1. After run completion + 24 hours, expire all `job:{run_id}:*` and `queue:{run_id}` keys
+2. Expire `spend:{run_id}` keys
+3. No audit log entry required (Redis data is operational, not compliance)
+
+### 4.5 Container Artifact Destruction
+
+Container artifacts are automatically destroyed (P5):
+
+- `--rm` flag on `docker run` ensures container removal on exit (`harness/dispatcher.py:34`)
+- tmpfs mounts are kernel-managed and cleared on unmount
+- No operator action required
+
+Verification: confirm no stopped containers remain with `docker ps -a --filter name=worker-*`
+
+### 4.6 Human Review Report Destruction
+
+Markdown reports in `{run_dir}/findings/`:
+
+Procedure:
+1. Verify the associated finding record has been retained for the required period
+2. Securely delete the markdown file (use `shred` on Linux, or equivalent secure delete)
+3. Record the deletion in the audit log
+
+---
+
+## 5. Regulatory Considerations
+
+### 5.1 FINRA / SOX
+
+**FINRA Rule 4511** requires broker-dealers to preserve books and records for periods specified in SEA Rules 17a-3 and 17a-4. For Mantis deployed in financial services:
+
+- Audit logs constitute business records of security testing activities and must be retained for 6 years (first 2 years in readily accessible storage)
+- The SHA-3 hash chain satisfies the "non-rewriteable, non-erasable" requirement for electronic storage (SEC Rule 17a-4(f))
+- Human review sign-offs constitute supervisory records
+
+**SOX Section 802** imposes criminal penalties for knowingly destroying audit workpapers within the retention period:
+
+- All audit log files must be preserved for minimum 7 years
+- Destruction must follow documented procedures with approvals
+- Audit log archival to immutable storage is recommended within 24 hours of run completion
+
+### 5.2 GDPR / CCPA
+
+Mantis scans open-source software, not personal data. However:
+
+**GDPR Article 5(1)(e)** (storage limitation): Data should be kept only as long as necessary.
+- Worker artifacts (tmpfs) satisfy this by being destroyed immediately
+- Finding data retained only for stated periods
+- Cryptographic erasure provides a GDPR-compliant destruction mechanism
+
+**GDPR Article 17** (right to erasure): If Mantis processes any data that could be linked to an individual (e.g., commit author names in source code):
+- Audit logs may reference file paths that include author names
+- Gap: no automated PII detection or redaction in audit log payloads
+- Mitigation: audit log payloads focus on operational metadata, not source content
+
+**CCPA Section 1798.105**: Similar right to deletion.
+- Cryptographic erasure satisfies CCPA deletion requirements for encrypted findings
+- Non-encrypted metadata in `runs`/`jobs` tables can be deleted per procedure 4.3
+
+### 5.3 FedRAMP / FISMA
+
+For federal government deployment:
+
+**NIST SP 800-53 AU-11** (audit record retention): Audit records retained per organizational policy (this document specifies 7 years).
+
+**NIST SP 800-53 SI-12** (information management and retention): Data handled in accordance with applicable laws, policies, and regulations (satisfied by this policy).
+
+**NIST SP 800-53 MP-6** (media sanitization): Cryptographic erasure is an approved sanitization method per NIST SP 800-88 Rev. 1 for data encrypted with approved algorithms (AES-256-GCM qualifies).
+
+---
+
+## 6. Key Management
+
+### 6.1 FINDINGS_ENC_KEY Lifecycle
+
+| Phase | Procedure |
+|-------|-----------|
+| Generation | Generate 32 bytes from CSPRNG (`os.urandom(32)`), base64-encode |
+| Storage | Secrets manager (Vault, AWS Secrets Manager, Azure Key Vault) in production; environment variable in dev |
+| Distribution | Injected at runtime via environment variable (`harness/crypto.py:30-37`) |
+| Rotation | Generate new key, re-encrypt all active findings with new key, destroy old key |
+| Destruction | Revoke from secrets manager, overwrite in all backup locations, record in audit log |
+
+### 6.2 Rotation Schedule
+
+| Key Type | Rotation Frequency | Trigger Events |
+|----------|-------------------|----------------|
+| FINDINGS_ENC_KEY | Annual or on compromise | Personnel change, suspected breach, compliance audit |
+| API keys (LLM providers) | Per provider policy | Personnel change, suspected misuse |
+| POSTGRES_PASSWORD | Quarterly | Personnel change, suspected breach |
+| REDIS_PASSWORD | Quarterly | Personnel change, suspected breach |
+
+---
+
+## 7. Policy Review
+
+This policy must be reviewed:
+- Annually at minimum
+- When regulatory requirements change
+- When the data architecture changes (new data types, new storage locations)
+- After any data breach or security incident
+- When deploying to a new regulatory jurisdiction
+
+**Approval required from**: Security Operations Lead and Compliance Officer

--- a/docs/compliance/incident-response-playbook.md
+++ b/docs/compliance/incident-response-playbook.md
@@ -1,0 +1,343 @@
+# Mantis Incident Response Playbook
+
+## When a Zero-Day Vulnerability is Discovered
+
+**Document version**: 1.0
+**Last updated**: 2026-04-25
+**Applicable system**: Mantis Autonomous Vulnerability Discovery Harness
+**Policy owner**: Security Operations Lead
+
+---
+
+## Overview
+
+This playbook defines the operational procedures for handling vulnerability discoveries made by the Mantis system. It covers the full lifecycle from initial automated discovery through coordinated disclosure. All actions must comply with the P1-P8 principles defined in `01-constitution.md`.
+
+**Cardinal rule (P2)**: No finding, disclosure, patch, or report reaches any external party without explicit human sign-off recorded in the audit log with timestamp and reviewer identity.
+
+---
+
+## Phase 1: Triage (Target: < 4 hours from discovery)
+
+### 1.1 Automated Pre-Triage (System-Performed)
+
+These steps are performed automatically by the Mantis pipeline before human involvement:
+
+1. **ASAN parser extracts crash metadata** (`harness/parser.py:150-202`)
+   - Crash type (heap-buffer-overflow, use-after-free, etc.)
+   - READ or WRITE direction
+   - Affected file, line, and function
+   - Severity tier (1-5) assigned automatically
+
+2. **CVSS estimate computed** (`harness/parser.py:88-91`)
+   - Tier 5 (control flow hijack): 9.0-10.0
+   - Tier 4 (arbitrary write): 7.5-9.0
+   - Tier 3 (arbitrary read): 5.0-7.5
+   - Tier 2 (DoS/crash): 3.5-5.0
+   - Tier 1 (memory leak): 1.0-3.5
+
+3. **Validation agent reviews finding** (`harness/validator.py:49-128`)
+   - Is the ASAN output consistent with a real memory safety bug?
+   - Is the reproduction case plausible and specific?
+   - Is this a meaningful security issue?
+   - Verdict: VALIDATE / REJECT / NEEDS_HUMAN_TRIAGE
+
+4. **Finding stored encrypted** (`harness/findings.py:114-156`)
+   - Exploit code, reproduction steps, and ASAN output encrypted with AES-256-GCM
+   - Finding enters human review queue ordered by severity tier
+
+5. **Audit trail established** (`harness/audit.py:39-88`)
+   - All discovery actions logged in hash-chained JSONL before execution
+   - Complete evidence chain from first tool call through validation verdict
+
+### 1.2 Human Triage (First Responder)
+
+When a finding appears in the human review queue (`harness/findings.py:191-207`):
+
+1. **Confirm ASAN output is a real memory safety bug**
+   - Review the ASAN output in the finding report
+   - Check crash type matches the parser's classification
+   - Verify the stack trace points to the reported file and function
+   - If ASAN output is absent or unclear, mark for deeper investigation
+
+2. **Review the validation agent verdict**
+   - VALIDATE: high confidence, proceed with triage
+   - NEEDS_HUMAN_TRIAGE: extra scrutiny required, agent was uncertain
+   - REJECT: should not normally appear in review queue (log review recommended)
+
+3. **Assess exploitability**
+   - Is the crash reachable from external input?
+   - Does the crash affect a commonly-used code path?
+   - Is the READ/WRITE classification correct?
+   - Could this be escalated beyond the assigned tier? (e.g., a controlled write that enables code execution = upgrade from Tier 4 to Tier 5)
+
+4. **Assign incident severity**
+   - Confirm or override the automated CVSS estimate
+   - Record the confirmed CVSS in the database via `record_human_review()` (`harness/findings.py:210-251`)
+   - The confirmed score replaces the estimate (`cvss_confirmed` column)
+
+5. **Verify the reproduction case**
+   - If possible, re-run the reproduction command in a fresh container
+   - Confirm the ASAN crash is deterministic (reproduces consistently)
+   - Document any modifications needed to reproduce
+
+6. **Record triage decision in audit log**
+   - Human review is recorded via `record_human_review()` which writes to both Postgres and audit log
+   - Include: reviewer identity, confirmed CVSS, disclosure decision
+
+---
+
+## Phase 2: Internal Review (Target: < 24 hours from triage)
+
+### 2.1 Assemble Review Team
+
+Based on severity tier:
+
+| Severity | Required Reviewers | Notification Method |
+|----------|-------------------|---------------------|
+| Tier 5 (RCE / control flow hijack) | CISO + Legal Counsel + Engineering Lead + Security Researcher | Direct contact (phone/in-person) |
+| Tier 4 (Arbitrary write) | Security Lead + Engineering Lead + Security Researcher | Secure messaging |
+| Tier 3 (Arbitrary read) | Security Lead + Security Researcher | Secure messaging |
+| Tier 2 (DoS/crash) | Security Team | Standard channels |
+| Tier 1 (Memory leak) | Security Team (batch review) | Weekly digest |
+
+### 2.2 Technical Deep Dive
+
+1. **Root cause analysis**
+   - Review the agent's full reasoning chain (available in finding report and audit log)
+   - Read the affected source code independently
+   - Determine if the bug is in the target project or in a dependency
+   - Identify all affected versions if possible
+
+2. **Impact assessment**
+   - What applications or products use the affected library?
+   - Is the vulnerable code path reachable in common configurations?
+   - Are there existing mitigations (ASLR, stack canaries, etc.) that reduce exploitability?
+   - What is the worst-case impact if exploited?
+
+3. **Candidate patch review**
+   - Review the agent-generated patch (`candidate_patch` in finding)
+   - Determine if the patch is correct and complete
+   - Check for regressions -- does the fix break legitimate functionality?
+   - Prepare a production-quality patch if the candidate is insufficient
+
+4. **Classify finding for disclosure track**
+
+   | Classification | Criteria | Disclosure Track |
+   |---------------|----------|-----------------|
+   | Critical (CVSS >= 9.0) | RCE, authentication bypass, data breach | Expedited: 30-day disclosure |
+   | High (CVSS 7.0-8.9) | Arbitrary write, privilege escalation | Standard: 90-day disclosure |
+   | Medium (CVSS 4.0-6.9) | Information leak, DoS | Standard: 90-day disclosure |
+   | Low (CVSS < 4.0) | Memory leak, minor crash | Extended: 120-day or batch disclosure |
+
+### 2.3 Legal Review (Tier 4-5 only)
+
+1. Does the target project have a responsible disclosure policy?
+2. Does the target project have a security contact (SECURITY.md, security@, HackerOne)?
+3. Are there contractual obligations with the target project's maintainers?
+4. Are there regulatory notification requirements (e.g., if the target is used in regulated infrastructure)?
+5. Document legal review outcome in the audit log
+
+---
+
+## Phase 3: Coordinated Disclosure
+
+### 3.1 Standard Timeline (90 + 45 days)
+
+```
+Day 0     : Vulnerability discovered by Mantis
+Day 0-1   : Phase 1 triage (< 4 hours) + Phase 2 internal review (< 24 hours)
+Day 1-7   : Prepare disclosure package
+Day 7     : INITIAL CONTACT with upstream maintainer (private channel)
+Day 7-14  : Confirm maintainer received report, establish communication channel
+Day 14-90 : Remediation period (maintainer develops and tests fix)
+Day 60    : Check-in with maintainer on progress
+Day 90    : Public disclosure deadline (if patch available)
+Day 90-135: Grace period (+45 days if maintainer requests and is actively working)
+Day 135   : Final disclosure deadline (regardless of patch status)
+```
+
+### 3.2 Disclosure Package Contents
+
+Prepare the following for the upstream maintainer (all content from encrypted findings store):
+
+1. **Vulnerability summary**: type, affected file/function/line, severity assessment
+2. **Reproduction steps**: exact commands to trigger the crash with ASAN
+3. **ASAN output**: full sanitizer output showing the crash
+4. **Candidate patch**: agent-generated fix (as a starting point, not guaranteed correct)
+5. **Impact assessment**: exploitability analysis from Phase 2
+6. **Contact information**: security team contact for follow-up questions
+
+**Do NOT include**: raw audit log entries, agent reasoning chains, internal review notes, Mantis system configuration details.
+
+### 3.3 Communication Channels (in preference order)
+
+1. Project's established security reporting mechanism (SECURITY.md, HackerOne, Bugcrowd)
+2. Security-specific email (security@project.org)
+3. Direct encrypted email to maintainer (PGP/GPG)
+4. Private issue on project's issue tracker (if supported)
+5. Direct message to maintainer on established platform
+
+All communications must be encrypted in transit. Record all outbound communications in the audit log.
+
+### 3.4 CVE Assignment Process
+
+1. **Determine CNA**: identify the appropriate CVE Numbering Authority
+   - If the target project is a CNA, they assign the CVE
+   - Otherwise, request through MITRE or the relevant root CNA
+2. **Request CVE ID** after maintainer acknowledges the vulnerability
+3. **Provide CVE details**: description, affected versions, CVSS score (human-confirmed), references
+4. **Coordinate publication**: align CVE publication with patch availability
+
+### 3.5 Escalation: Maintainer Non-Response
+
+| Day | Action |
+|-----|--------|
+| Day 7 | Initial contact sent |
+| Day 14 | If no response: second contact attempt via alternate channel |
+| Day 21 | If no response: escalate to CERT/CC or relevant national CERT |
+| Day 30 | If no response: notify CISO; begin planning unilateral disclosure |
+| Day 90 | If no response and no patch: proceed with public disclosure per policy |
+
+---
+
+## Phase 4: Post-Incident Review (Target: < 2 weeks after disclosure)
+
+### 4.1 Retrospective
+
+Conduct a post-incident review covering:
+
+1. **Timeline review**
+   - How long from discovery to triage?
+   - How long from triage to maintainer contact?
+   - Was the 90+45 day timeline respected?
+   - Were there avoidable delays?
+
+2. **Quality assessment**
+   - Was the ASAN output correctly interpreted?
+   - Was the severity assessment accurate?
+   - Was the candidate patch useful to the maintainer?
+   - Did the validation agent correctly classify the finding?
+
+3. **Process improvements**
+   - What would have made triage faster?
+   - Were the right people notified at the right time?
+   - Are there tools or automation that would help?
+
+4. **Mantis system improvements**
+   - Should the parser's severity mapping be updated?
+   - Should the validation prompt be refined?
+   - Are there new crash types to add to the taxonomy?
+
+### 4.2 Metrics to Track
+
+| Metric | Target |
+|--------|--------|
+| Time from discovery to triage completion | < 4 hours |
+| Time from triage to internal review completion | < 24 hours |
+| Time from internal review to maintainer contact | < 7 days |
+| False positive rate (findings rejected at human review) | < 20% |
+| Validation agent accuracy (agreement with human reviewer) | > 80% |
+| Maintainer response rate (within 14 days) | > 70% |
+| Successful coordinated disclosure rate | > 90% |
+
+### 4.3 Documentation
+
+1. Archive the complete finding record (encrypted) per data retention policy
+2. Update the finding's status in the database
+3. Record the disclosure outcome in the audit log
+4. If a CVE was assigned, record the CVE ID
+5. File the retrospective notes for future reference
+
+---
+
+## Escalation Matrix
+
+| Severity | Crash Category | Examples | Notification | Timeline |
+|----------|---------------|----------|-------------|----------|
+| Tier 5 (CVSS 9.0-10.0) | Control flow hijack | RIP/PC control, arbitrary write to code pointer, RCE | CISO + Legal + Engineering Lead | Within 4 hours of confirmation |
+| Tier 4 (CVSS 7.5-9.0) | Arbitrary write | heap-buffer-overflow WRITE, stack-buffer-overflow WRITE | Security Lead + Engineering Lead | Within 24 hours |
+| Tier 3 (CVSS 5.0-7.5) | Arbitrary read | heap-buffer-overflow READ, use-after-free READ | Security Lead | Within 48 hours |
+| Tier 2 (CVSS 3.5-5.0) | DoS / crash | NULL dereference, stack overflow, abort | Security Team weekly digest | Next business day |
+| Tier 1 (CVSS 1.0-3.5) | Memory leak only | LeakSanitizer finding, no crash | Security Team monthly report | Monthly |
+
+Reference: `harness/parser.py:23-40` (severity tier definitions), `02-specification.md:275-283` (crash taxonomy)
+
+---
+
+## Special Scenarios
+
+### S1: Vulnerability in Widely-Deployed Infrastructure (e.g., OpenSSL, glibc)
+
+1. Escalate immediately to Tier 5 timeline regardless of CVSS score
+2. Engage Legal within 4 hours
+3. Contact national CERT (US-CERT, CERT/CC) in parallel with upstream maintainer
+4. Consider embargo coordination with other known users of the affected software
+5. Prepare customer advisory draft during remediation period
+
+### S2: Duplicate Finding (vulnerability already known/disclosed)
+
+1. Check NVD, CVE databases, and project issue tracker before initiating disclosure
+2. If a CVE already exists: document the duplicate, close the finding, record in audit log
+3. If being actively fixed: monitor for patch and verify the fix addresses the root cause
+4. Report generation still has value: our reproduction case may differ from the original report
+
+### S3: Finding in Mantis's Own Dependencies
+
+1. Treat as an internal security incident
+2. Assess if the vulnerability affects Mantis operation (e.g., in litellm, cryptography, asyncpg)
+3. Apply patch immediately if available; pin to fixed version
+4. If the vulnerability affects the `cryptography` library used for AES-256-GCM: emergency key rotation
+
+### S4: Legal Hold / Litigation
+
+1. Suspend all data destruction for related findings immediately
+2. Preserve all audit logs, finding records, and human review reports
+3. Disable cryptographic erasure for affected encryption keys
+4. Notify Legal and Compliance
+5. Document the hold scope and affected records in the audit log
+
+### S5: Accidental Disclosure
+
+If vulnerability details are accidentally made public before coordinated disclosure:
+
+1. Immediately notify the upstream maintainer with full details
+2. Escalate to CISO and Legal
+3. Contact CERT/CC for emergency coordination
+4. Request expedited CVE assignment
+5. Prepare public advisory with available mitigations
+6. Conduct root cause analysis of the accidental disclosure
+7. Update procedures to prevent recurrence
+
+---
+
+## Roles and Responsibilities
+
+| Role | Responsibilities |
+|------|-----------------|
+| **Security Researcher** (first responder) | Triage findings, verify reproduction, confirm severity, perform technical analysis |
+| **Security Lead** | Approve disclosure decisions, coordinate with upstream maintainers, manage timelines |
+| **Engineering Lead** | Review candidate patches, assess impact on downstream consumers |
+| **CISO** | Approve Tier 5 disclosures, manage organizational risk, authorize CERT engagement |
+| **Legal Counsel** | Review disclosure obligations, manage legal hold, advise on regulatory requirements |
+| **Mantis Operator** | Run scans, manage infrastructure, escalate system issues |
+
+---
+
+## Audit Requirements
+
+Every action in this playbook must satisfy P3 (every action logged before execution):
+
+- Triage decisions recorded via `record_human_review()` (`harness/findings.py:210-251`)
+- Disclosure approvals recorded in audit log with `event_type: "disclosure_approved"`
+- Human reviewer identity recorded in both database and audit log
+- All timestamps in UTC
+- Audit log hash chain must verify cleanly at any point (`harness/audit.py:93-123`)
+
+Audit log event types relevant to this playbook:
+- `finding_validated`: automated validation complete (`harness/validator.py:114-127`)
+- `human_review`: human triage complete (`harness/findings.py:241-251`)
+- `disclosure_approved`: external communication authorized
+- `disclosure_sent`: upstream maintainer contacted
+- `disclosure_public`: vulnerability publicly disclosed
+- `cve_assigned`: CVE ID assigned to finding

--- a/docs/compliance/nist-800-218-ssdf-mapping.md
+++ b/docs/compliance/nist-800-218-ssdf-mapping.md
@@ -1,0 +1,108 @@
+# NIST SP 800-218 (SSDF) v1.1 -- Mantis Compliance Mapping
+
+**Document version**: 1.0
+**Last updated**: 2026-04-25
+**Applicable system**: Mantis Autonomous Vulnerability Discovery Harness
+**Framework**: NIST SP 800-218 — Secure Software Development Framework (SSDF) v1.1
+
+---
+
+## Overview
+
+This document maps each SSDF practice group and task to the corresponding Mantis implementation. Evidence locations reference actual file paths in the repository. Gaps are identified honestly and marked with planned remediation.
+
+---
+
+## PO: Prepare the Organization
+
+| Practice | Task | Mantis Implementation | Evidence |
+|----------|------|----------------------|----------|
+| PO.1 | Define security requirements for software development | P1-P8 non-negotiable principles define enforceable security requirements: isolation, human review, audit logging, credential hygiene, ephemeral containers, cost tracking, human severity confirmation, exploit containment. | `01-constitution.md:19-41` |
+| PO.1.1 | Define security requirements | Eight codified principles (P1-P8) serve as the security requirements baseline. They are defined as "non-negotiable" and cover isolation, access control, audit, credential management, data-at-rest encryption, and human oversight. | `01-constitution.md:19-41` |
+| PO.1.2 | Communicate requirements to third parties | The system uses litellm for all LLM provider interactions; third-party API keys are injected at runtime only (P4). Network egress is restricted to allowlisted API endpoints. No third-party code executes outside Docker containers. | `harness/config.py:60-64`, `scripts/setup-network.sh:12` |
+| PO.1.3 | Review and update security requirements | Gap -- planned. No formal periodic review cadence for the constitution is currently defined. The constitution is version-controlled in git, providing change history. See issue #17. | `01-constitution.md` (git history) |
+| PO.2 | Implement roles and responsibilities | Gap -- partial. The system enforces role separation between automated agents and human reviewers (P2, P7). Human reviewer identity is recorded in audit log and findings store. No formal RBAC system for operator/reviewer/admin roles exists yet. See issue #18. | `harness/findings.py:210-251` (human reviewer field), `01-constitution.md:23-24` (P2) |
+| PO.2.1 | Identify software development roles | Two roles are implicit: operator (runs scans) and human reviewer (confirms findings, approves disclosure). Agent actors are distinguished in audit log entries (`orchestrator`, `worker`, `validation_agent`, `human:{name}`). | `harness/audit.py:70-78` (actor field) |
+| PO.2.2 | Identify security-relevant roles | The audit log tracks actor identity on every entry. Human review requires named reviewer identity for sign-off. Disclosure requires explicit human approval. | `harness/findings.py:210-251`, `02-specification.md:423-432` |
+| PO.2.3 | Provide role-specific training | Gap -- planned. No training materials or runbooks exist for operators or reviewers. See issue #19. | N/A |
+| PO.3 | Implement supporting toolchains | Development toolchain: ruff linter/formatter, pre-commit hooks, pytest with coverage, Alembic for migrations. Runtime toolchain: Docker containers, clang/ASAN, Redis, Postgres. | `Makefile`, `.pre-commit-config.yaml`, `pyproject.toml` |
+| PO.3.1 | Specify required toolchains | Toolchain requirements are codified: Python 3.12+, clang with AddressSanitizer, Docker, Redis, Postgres. Worker container image specifies all packages installed at build time. | `01-constitution.md:47-54`, `worker/Dockerfile:1-23` |
+| PO.3.2 | Evaluate and select tools | litellm selected for provider-agnostic LLM access. ASAN selected as the deterministic ground-truth oracle for memory safety. SHA-3 selected for hash chain integrity. AES-256-GCM selected for encryption at rest. All choices documented. | `01-constitution.md:48-54`, `harness/crypto.py:1-2`, `harness/audit.py:1` |
+| PO.3.3 | Ensure toolchain security | Worker container images are built credential-free (P4). Pre-commit hooks enforce code quality. Dependencies pinned in `requirements.txt` and `agent/requirements.txt`. | `worker/Dockerfile:29-31`, `01-constitution.md:29` |
+| PO.4 | Define and use criteria for software security checks | Static analysis (ruff), pre-commit hooks, unit tests, and integration tests enforce quality gates. ASAN provides runtime memory safety verification. Validation agent provides automated finding review. | `Makefile` (check target), `harness/validator.py:49-128` |
+| PO.4.1 | Define criteria for security checks | Severity tier system (1-5) with CVSS ranges defined. Validation agent uses explicit criteria: ASAN consistency, reproduction plausibility, security meaningfulness. | `harness/parser.py:23-40`, `harness/validator.py:16-37` |
+| PO.4.2 | Implement criteria | Validation agent enforces three-question assessment with explicit verdict routing: VALIDATE, REJECT, or NEEDS_HUMAN_TRIAGE. | `harness/validator.py:93-127` |
+| PO.5 | Implement and maintain secure environments | Worker containers run with `--cap-drop ALL`, `--security-opt no-new-privileges`, read-only root filesystem, memory limits, and restricted network egress. | `harness/dispatcher.py:55-77`, `worker/Dockerfile:33-34`, `scripts/setup-network.sh` |
+| PO.5.1 | Separate development from production | Worker containers are isolated from orchestrator infrastructure. Source is mounted read-only. tmpfs workspace is destroyed on container exit. No shared state between workers. | `harness/dispatcher.py:43-45` (`:ro` mount), `worker/entrypoint.sh:22-24` |
+| PO.5.2 | Protect development environments | Gap -- partial. No formal developer workstation security policy. Production secrets are environment-variable only (P4) and never committed. `.env` files excluded from git. See issue #20. | `01-constitution.md:29` |
+
+---
+
+## PS: Protect the Software
+
+| Practice | Task | Mantis Implementation | Evidence |
+|----------|------|----------------------|----------|
+| PS.1 | Protect all forms of code | Source code in git with branch protection. Docker images built without credentials (P4). Exploit code encrypted at rest with AES-256-GCM (P8). | `01-constitution.md:29, 40-41`, `harness/crypto.py:13-18` |
+| PS.1.1 | Store code securely | Findings with exploit code stored in Postgres with AES-256-GCM encrypted columns (`reproduction_enc`, `patch_enc`, `asan_output_enc`). Encryption key loaded from environment variable, never from disk or config file. | `harness/findings.py:125-127`, `harness/crypto.py:30-37`, `migrations/versions/001_initial_schema.py:75-77` |
+| PS.1.2 | Protect code integrity | Audit log uses SHA-3 hash chain for tamper evidence. Each entry's `this_hash` covers the full JSON including `prev_hash`. Chain verification function provided. | `harness/audit.py:81-83` (hash computation), `harness/audit.py:93-123` (verify_chain) |
+| PS.2 | Verify third-party components | Gap -- partial. Worker container installs packages at build time from Ubuntu and PyPI repositories. No SBOM generation or dependency vulnerability scanning pipeline exists. See issue #21. | `worker/Dockerfile:5-23` |
+| PS.2.1 | Identify third-party components | Dependencies listed in `requirements.txt` files. Container packages enumerated in Dockerfile. No automated SBOM tool. | `worker/Dockerfile:5-23`, `worker/agent/requirements.txt` |
+| PS.2.2 | Verify third-party components | Gap -- planned. No automated dependency vulnerability scanning (e.g., `pip-audit`, `trivy`). See issue #21. | N/A |
+| PS.3 | Configure build processes | Build processes use specific compiler flags for ASAN instrumentation. Entrypoint script handles autotools, CMake, and plain Makefile projects with consistent ASAN flags. | `worker/entrypoint.sh:35-84` |
+| PS.3.1 | Use well-defined build processes | Entrypoint script defines deterministic build sequence: autotools > CMake > Makefile. Compiler flags hardcoded for ASAN (`-fsanitize=address -g -O1 -fno-omit-frame-pointer`). Build failures produce structured JSON error output. | `worker/entrypoint.sh:35-91` |
+| PS.3.2 | Protect build artifacts | Pre-compiled binaries mounted read-only into containers (`:ro`). Built binaries placed in tmpfs, destroyed on container exit (P5). Docker images built credential-free (P4). | `harness/dispatcher.py:48-49`, `worker/entrypoint.sh:30-33` |
+
+---
+
+## PW: Produce Well-Secured Software
+
+| Practice | Task | Mantis Implementation | Evidence |
+|----------|------|----------------------|----------|
+| PW.1 | Design software to meet security requirements | Architecture designed around 8 non-negotiable security principles. Five-stage pipeline with isolation at every boundary. Separate validation agent prevents single-point-of-failure in finding quality. | `01-constitution.md:19-41`, `02-specification.md:1-31` |
+| PW.1.1 | Use secure design principles | Defense in depth: container isolation (P1) + network restriction + capability dropping + read-only filesystem + separate validation agent + mandatory human review (P2). Least privilege: `--cap-drop ALL`, non-root user (UID 1001). | `worker/Dockerfile:33-34`, `harness/dispatcher.py:74-76`, `scripts/setup-network.sh:38-40` |
+| PW.1.2 | Evaluate security risk of design | Threat model documented (see `docs/compliance/threat-model.md`). Container escape, LLM provider compromise, and audit log tampering identified as primary risks. | `docs/compliance/threat-model.md` |
+| PW.2 | Review the software design | Gap -- partial. Design documented in specification but no formal design review process with sign-off. Architecture decisions are recorded in `01-constitution.md` and `02-specification.md`. See issue #22. | `02-specification.md` |
+| PW.4 | Reuse existing, well-secured software | Uses established libraries: litellm (LLM abstraction), cryptography (AES-256-GCM), asyncpg (Postgres), pydantic (validation). Does not implement custom cryptography. | `harness/crypto.py:8` (cryptography.hazmat), `harness/llm.py:8` (litellm), `harness/findings.py:8` (asyncpg) |
+| PW.4.1 | Prefer established components | AES-256-GCM via Python `cryptography` library (not custom). SHA-3 via Python `hashlib` stdlib. litellm for LLM provider abstraction. All standard, audited libraries. | `harness/crypto.py:8`, `harness/audit.py:4` |
+| PW.5 | Create source code by adhering to secure coding practices | Ruff linter enforces code quality (E, F, I, W rules). Pre-commit hooks run on every commit. Async/await patterns used throughout for proper resource management. | `pyproject.toml`, `.pre-commit-config.yaml` |
+| PW.5.1 | Follow secure coding practices | Input validation via pydantic models. SQL parameterized queries (no string concatenation). Encryption key validation (32-byte check). JSON parsing with error handling. | `harness/config.py:37-96` (pydantic), `harness/findings.py:131-153` (parameterized SQL), `harness/crypto.py:35-37` (key validation) |
+| PW.6 | Configure software to have secure settings by default | Default configuration: 4 parallel workers, $100 per-run spend limit, $500 per-day limit, 30-minute container timeout, 4GB memory limit. Static ranker (no API cost) as default ranking strategy. | `harness/config.py:54-84` |
+| PW.6.1 | Define secure default settings | Defaults are restrictive: low parallelism, conservative spend limits, short timeouts. Network egress deny-all by default with explicit allowlist. | `harness/config.py:68-83`, `scripts/setup-network.sh:62-63` |
+| PW.7 | Review and analyze human-readable code | Pre-commit hooks enforce linting and formatting. Validation agent reviews findings programmatically. Human review mandatory for all findings before external action (P2). | `.pre-commit-config.yaml`, `harness/validator.py:49-128` |
+| PW.7.1 | Perform code review | Gap -- partial. Pre-commit hooks provide automated checks. No formal peer code review process is mandated for Mantis development itself. See issue #22. | `.pre-commit-config.yaml` |
+| PW.8 | Test executable code | Unit tests (35+) and integration tests (8+) with pytest. ASAN provides runtime memory safety testing of target binaries. Audit chain verification function serves as integrity test. | `tests/unit/`, `tests/integration/`, `harness/audit.py:93-123` |
+| PW.8.1 | Use automated testing | `make test` runs unit tests with coverage. `make test-all` runs integration tests. Pre-commit hooks run linting on every commit. | `Makefile` |
+| PW.8.2 | Perform fuzz testing | The core product IS a fuzz/vulnerability testing tool. ASAN is the ground-truth oracle. Agent-generated inputs serve as intelligent, targeted fuzz inputs. | `worker/agent/loop.py`, `harness/parser.py:9-17` |
+| PW.9 | Configure software to have secure settings | Configuration via YAML + env var override (pydantic-settings). Env vars take precedence for secrets. No secrets in config files. | `harness/config.py:37-96` |
+| PW.9.1 | Define secure configuration | All sensitive values (API keys, encryption keys) loaded from environment variables, never from YAML. Key validation enforces 32-byte length for AES-256. | `harness/config.py:86-88`, `harness/crypto.py:30-37` |
+
+---
+
+## RV: Respond to Vulnerabilities
+
+| Practice | Task | Mantis Implementation | Evidence |
+|----------|------|----------------------|----------|
+| RV.1 | Identify and confirm vulnerabilities | Five-stage pipeline: agent discovers, ASAN confirms, parser extracts metadata, validation agent filters, human confirms. Three-question validation: ASAN real? Repro plausible? Security meaningful? | `harness/parser.py:150-202`, `harness/validator.py:49-128` |
+| RV.1.1 | Gather vulnerability information | ASAN output parsed for crash type, READ/WRITE direction, location (file, line, function). Agent provides reproduction commands, candidate patches, confidence level, and reasoning. | `harness/parser.py:63-92` (detection), `02-specification.md:270-310` (parser output schema) |
+| RV.1.2 | Assess vulnerability severity | Automated severity tier (1-5) with CVSS estimate ranges. P7 mandates human confirmation of severity before any external action. `cvss_estimate` vs `cvss_confirmed` columns enforce this distinction. | `harness/parser.py:23-40`, `01-constitution.md:37-38`, `migrations/versions/001_initial_schema.py:68-69` |
+| RV.1.3 | Validate vulnerabilities | Validation agent (Stage 5) uses separate LLM call to independently assess each finding. Three retries on failure. Verdicts: VALIDATE, REJECT, NEEDS_HUMAN_TRIAGE. | `harness/validator.py:49-128` |
+| RV.2 | Assess and prioritize vulnerabilities | Severity tier determines priority in human review queue (`ORDER BY severity_tier DESC`). Tier 5 (RCE) prioritized above Tier 1 (memory leak). | `harness/findings.py:191-207` (list_pending_review), `harness/parser.py:33-40` (CVSS ranges) |
+| RV.2.1 | Prioritize vulnerability response | Human review queue ordered by severity tier. Validation verdict determines routing: VALIDATE goes to review queue, REJECT is logged but not queued, NEEDS_HUMAN_TRIAGE gets lower priority with extra scrutiny flag. | `harness/findings.py:191-207`, `02-specification.md:347-349` |
+| RV.3 | Respond to vulnerabilities | Incident response playbook defined (see `docs/compliance/incident-response-playbook.md`). P2 enforces human sign-off before any external disclosure. Audit log records disclosure approval. | `docs/compliance/incident-response-playbook.md`, `harness/findings.py:210-251` |
+| RV.3.1 | Remediate vulnerabilities | System generates candidate patches as part of findings. Human reviewer must approve patches before submission. Disclosure approval tracked in database and audit log. | `harness/findings.py:210-251` (record_human_review), `02-specification.md:423-432` (reviewer sign-off) |
+| RV.3.2 | Communicate vulnerability information | Gap -- partial. Finding reports generated in structured markdown with all necessary context. No automated notification system for stakeholders. Coordinated disclosure timeline defined in incident response playbook but not enforced by code. See issue #23. | `harness/findings.py:15-63` (REPORT_TEMPLATE) |
+| RV.3.3 | Track vulnerabilities | Findings stored in Postgres with full lifecycle tracking: discovery, validation verdict, human review status, reviewer identity, review timestamp, disclosure approval. | `migrations/versions/001_initial_schema.py:58-87` |
+
+---
+
+## Summary of Gaps
+
+| Gap | SSDF Practice | Description | Planned Remediation |
+|-----|--------------|-------------|---------------------|
+| Periodic requirements review | PO.1.3 | No formal review cadence for P1-P8 | Issue #17 |
+| Formal RBAC | PO.2 | Roles are implicit, no access control system | Issue #18 |
+| Training materials | PO.2.3 | No operator/reviewer training | Issue #19 |
+| Developer workstation policy | PO.5.2 | No formal dev security policy | Issue #20 |
+| SBOM and dependency scanning | PS.2 | No automated supply chain verification | Issue #21 |
+| Formal design/code review process | PW.2, PW.7.1 | No mandated peer review for Mantis code | Issue #22 |
+| Automated disclosure notifications | RV.3.2 | No notification system for stakeholders | Issue #23 |

--- a/docs/compliance/nist-csf-2.0-mapping.md
+++ b/docs/compliance/nist-csf-2.0-mapping.md
@@ -1,0 +1,173 @@
+# NIST Cybersecurity Framework 2.0 -- Mantis Compliance Mapping
+
+**Document version**: 1.0
+**Last updated**: 2026-04-25
+**Applicable system**: Mantis Autonomous Vulnerability Discovery Harness
+**Framework**: NIST Cybersecurity Framework (CSF) 2.0
+
+---
+
+## Overview
+
+This document maps NIST CSF 2.0 functions and subcategories to Mantis controls, cross-referencing the P1-P8 non-negotiable principles from the Mantis constitution. Evidence locations reference actual file paths in the codebase.
+
+---
+
+## GV: Govern
+
+The Govern function establishes and monitors the organization's cybersecurity risk management strategy, expectations, and policy.
+
+| Subcategory | Mantis Implementation | Principle | Evidence |
+|-------------|----------------------|-----------|----------|
+| GV.OC-01: Organizational context for cybersecurity risk management is understood | Mantis is purpose-built for defensive security research in regulated industries (financial services, federal government). The constitution defines the operational context and constraints. | -- | `01-constitution.md:1-6` |
+| GV.OC-02: Internal and external stakeholders are identified | Two primary stakeholder roles: operators (run scans, manage infrastructure) and human reviewers (confirm findings, approve disclosure). Audit log actor field distinguishes `orchestrator`, `worker`, `validation_agent`, and `human:{name}`. | P2, P7 | `harness/audit.py:70-78`, `harness/findings.py:210-251` |
+| GV.OC-03: Legal, regulatory, and contractual requirements are understood | System designed for FINRA/SOX, GDPR/CCPA compliance. Data retention and destruction policies documented. Coordinated disclosure follows 90+45 day timeline. | P2 | `docs/compliance/data-retention-policy.md`, `01-constitution.md:1-6` |
+| GV.OC-04: Critical objectives, capabilities, and services are determined | Five-stage vulnerability discovery pipeline with defined success criteria: find true-positive vulnerabilities, produce structured reports, maintain audit trail, stay within cost limits. | -- | `01-constitution.md:63-73`, `02-specification.md:1-31` |
+| GV.OC-05: Outcomes, capabilities, and services dependencies are determined | Dependencies: Docker runtime, Redis queue, Postgres database, LLM provider API (configurable). All external dependencies documented. | -- | `01-constitution.md:47-54`, `harness/config.py:37-96` |
+| GV.RM-01: Risk management objectives are established | P1-P8 principles define risk tolerance: zero tolerance for credential leakage, unreviewed disclosure, or unlogged actions. Explicit spend limits control financial risk. | P1-P8 | `01-constitution.md:19-41` |
+| GV.RM-02: Risk appetite and tolerance are determined | Cost limits: $100/run default, $500/day default. Container timeout: 30 minutes. Memory limit: 4GB per container. All configurable but with conservative defaults. | P6 | `harness/config.py:71-83` |
+| GV.RM-03: Enterprise risk management and cybersecurity risk are aligned | Gap -- partial. No formal enterprise risk management integration. The system maintains its own risk posture through P1-P8 but does not integrate with organizational ERM tools. See issue #24. | -- | N/A |
+| GV.RM-07: Strategic opportunities are characterized | Gap -- not applicable. Mantis is a security tool, not a business system. Risk opportunities are identified through vulnerability discovery. | -- | N/A |
+| GV.RR-01: Organizational leadership establishes cybersecurity roles and responsibilities | Constitution mandates human review (P2) and human severity confirmation (P7). Reviewer identity recorded in database and audit log. | P2, P7 | `01-constitution.md:23-24, 37-38` |
+| GV.RR-02: Roles, responsibilities, and authorities are established | Audit log enforces actor accountability: every entry records who performed each action. Human review function requires named reviewer. | P3 | `harness/audit.py:70-78`, `harness/findings.py:213` |
+| GV.PO-01: Policy for managing cybersecurity risk is established | P1-P8 constitution serves as the cybersecurity policy. It is version-controlled in git. Defined as "non-negotiable" and "not configurable, not bypassable, not optional" (P2). | P1-P8 | `01-constitution.md:19-41` |
+| GV.PO-02: Policy for managing cybersecurity risk is communicated | Constitution is the first file in the repository and is referenced by all design documents. CLAUDE.md provides operational guidance for developers. | -- | `01-constitution.md`, `CLAUDE.md` |
+| GV.SC-01: Cybersecurity supply chain risk management program is established | Gap -- partial. Dependencies installed from standard repositories (Ubuntu apt, PyPI). No formal supply chain risk management or SBOM. See issue #21. | -- | `worker/Dockerfile:5-23` |
+| GV.SC-02: Cybersecurity roles for suppliers and partners are established | LLM provider interactions are constrained: egress-only network to allowlisted endpoints, API keys injected at runtime only, no persistent credentials. | P1, P4 | `scripts/setup-network.sh:12`, `01-constitution.md:29` |
+
+---
+
+## ID: Identify
+
+The Identify function helps determine the current cybersecurity risk to the organization.
+
+| Subcategory | Mantis Implementation | Principle | Evidence |
+|-------------|----------------------|-----------|----------|
+| ID.AM-01: Inventories of hardware and software assets are maintained | Worker container image contents defined in Dockerfile. Python dependencies in requirements files. System components documented in specification. | -- | `worker/Dockerfile:1-41`, `02-specification.md` |
+| ID.AM-02: Inventories of software platforms and applications are maintained | Container base image (`ubuntu:24.04`), installed packages (clang, gdb, lldb, valgrind, etc.), and Python packages (litellm, jinja2) are enumerated in Dockerfile. | -- | `worker/Dockerfile:1-31` |
+| ID.AM-03: Data assets are identified | Data classification defined: audit logs, finding metadata, exploit code/PoC, worker artifacts, API keys. See data retention policy. | P3, P8 | `docs/compliance/data-retention-policy.md` |
+| ID.AM-05: Resources are prioritized based on classification | Exploit code classified as Restricted (encrypted). Audit logs classified as Compliance (integrity-protected). API keys classified as Secret (environment-only). | P8 | `docs/compliance/data-retention-policy.md`, `harness/crypto.py:13-18` |
+| ID.AM-07: Data flows are mapped | Five-stage pipeline data flow documented in specification. Data flow from target repo through ranking, dispatch, worker analysis, parsing, validation, to human review. | -- | `02-specification.md:8-31` |
+| ID.AM-08: Systems and assets criticality is assessed | Findings severity tier (1-5) provides criticality assessment for discovered vulnerabilities. Infrastructure components prioritized by role (audit log, findings store, worker containers). | P7 | `harness/parser.py:23-40`, `docs/compliance/threat-model.md` |
+| ID.RA-01: Vulnerabilities in assets are identified | This IS the core function of Mantis. ASAN identifies memory safety vulnerabilities. Static ranker identifies high-risk code files. Parser extracts structured vulnerability metadata. | -- | `harness/parser.py:150-202`, `harness/static_ranker.py` |
+| ID.RA-02: Threat intelligence is received from information sharing forums | Gap -- not implemented. Mantis discovers new vulnerabilities rather than consuming threat intelligence feeds. Could integrate with NVD/CVE databases for context. See issue #25. | -- | N/A |
+| ID.RA-03: Internal and external threats are identified | Threat model documents threats to the Mantis system itself (container escape, LLM compromise, audit tampering). See threat model. | -- | `docs/compliance/threat-model.md` |
+| ID.RA-04: Potential impacts and likelihoods are identified | STRIDE threat analysis with likelihood/impact assessment. Residual risk register maintained. CVSS estimates provide vulnerability impact assessment. | P7 | `docs/compliance/threat-model.md`, `harness/parser.py:33-40` |
+| ID.RA-05: Threats, vulnerabilities, likelihoods, and impacts are used to understand risk | Severity tier system maps crash types to risk levels. CVSS estimation provides quantitative risk score. Human reviewer must confirm before action. | P7 | `harness/parser.py:82-91`, `01-constitution.md:37-38` |
+| ID.RA-06: Risk responses are chosen | Validation agent routing: VALIDATE (high confidence), REJECT (false positive), NEEDS_HUMAN_TRIAGE (uncertain). Human reviewer makes final disposition. | P2, P7 | `harness/validator.py:93-127`, `02-specification.md:347-349` |
+| ID.IM-01: Improvements from risk assessments are documented | Gap -- partial. Finding reports include full reasoning chain. No formal lessons-learned or improvement tracking process. See issue #26. | -- | `harness/findings.py:15-63` |
+
+---
+
+## PR: Protect
+
+The Protect function supports the ability to secure assets to prevent or lower the likelihood and impact of cybersecurity events.
+
+| Subcategory | Mantis Implementation | Principle | Evidence |
+|-------------|----------------------|-----------|----------|
+| PR.AA-01: Identities and credentials are managed | API keys loaded from environment variables, never persisted in images or config files (P4). Encryption key validated for correct length (32 bytes). Human reviewer identity recorded by name. | P4 | `harness/crypto.py:30-37`, `01-constitution.md:29`, `harness/findings.py:213` |
+| PR.AA-02: Identities are proofed and bound to credentials | Gap -- partial. Human reviewer identity is recorded as a string (name), but no authentication system verifies reviewer identity. See issue #18. | P2 | `harness/findings.py:213` |
+| PR.AA-03: Users and services are authenticated | Gap -- partial. No authentication layer for CLI or API access. Database access controlled by Postgres credentials. API keys authenticate to LLM providers. See issue #18. | P4 | `harness/config.py:82` |
+| PR.AA-05: Access permissions and authorizations are defined | Filesystem: target source mounted read-only, workspace on tmpfs. Container: `--cap-drop ALL`, `no-new-privileges`. Network: egress allowlist only. Database: encrypted sensitive columns. | P1, P8 | `harness/dispatcher.py:43-76`, `scripts/setup-network.sh:62-63` |
+| PR.AA-06: Physical access is managed | Gap -- not applicable at application level. Physical security is the responsibility of the deployment environment (data center, cloud provider). | -- | N/A |
+| PR.AT-01: Awareness and training are provided | Gap -- planned. No formal security awareness training for operators. See issue #19. | -- | N/A |
+| PR.AT-02: Individuals in specialized roles are provided awareness and training | Gap -- planned. No reviewer training materials. Incident response playbook provides operational guidance. See issue #19. | -- | `docs/compliance/incident-response-playbook.md` |
+| PR.DS-01: Data-at-rest is protected | Exploit code, reproduction steps, and ASAN output stored with AES-256-GCM encryption in Postgres. 96-bit random nonce per encryption operation. Key loaded from environment variable. | P8 | `harness/crypto.py:13-18`, `harness/findings.py:125-127` |
+| PR.DS-02: Data-in-transit is protected | LLM API calls use HTTPS (port 443 only, enforced by iptables). No plaintext exploit code transmitted. | P1, P8 | `scripts/setup-network.sh:67-69` (port 443 only) |
+| PR.DS-10: Data-in-use is protected | Worker containers use tmpfs for workspace (data in RAM only, destroyed on exit). Container memory limited to 4GB. No swap (`--memory-swap` equals `--memory`). | P5 | `harness/dispatcher.py:38-39`, `02-specification.md:237` |
+| PR.DS-11: Data backups are created and protected | Gap -- planned. No automated backup for Postgres findings store or audit logs. Audit logs are append-only files that can be backed up with standard tools. See issue #27. | -- | N/A |
+| PR.IR-01: Incident response plans are established | Incident response playbook defines four phases: Triage, Internal Review, Coordinated Disclosure, Post-Incident Review. Escalation matrix based on severity tier. | P2 | `docs/compliance/incident-response-playbook.md` |
+| PR.PS-01: Configuration management practices are established | Configuration via YAML + environment variable override (pydantic-settings). Env vars take precedence. All config fields have secure defaults. | -- | `harness/config.py:37-96` |
+| PR.PS-02: Software is maintained and replaced | Container images rebuilt from Dockerfile. Ubuntu base image can be updated. Dependencies updated via requirements files. Alembic manages database schema migrations. | -- | `worker/Dockerfile`, `migrations/versions/001_initial_schema.py` |
+| PR.PS-04: Log records are generated | SHA-3 hash-chained JSONL audit log records every action before execution (P3). Includes: event type, actor, timestamp, payload, sequence number, hash chain. File locking ensures atomicity. | P3 | `harness/audit.py:39-88` |
+| PR.PS-05: Installation and disposal of hardware and software is managed | Containers created fresh per job and destroyed after result collection (P5). `--rm` flag on `docker run`. tmpfs destroyed on exit. No persistent state in containers. | P5 | `harness/dispatcher.py:34` (`--rm`), `01-constitution.md:32-33` |
+| PR.PS-06: Secure software development practices are integrated | Pre-commit hooks, ruff linting, unit tests with coverage, integration tests. SSDF mapping documents compliance. | -- | `Makefile`, `.pre-commit-config.yaml`, `docs/compliance/nist-800-218-ssdf-mapping.md` |
+| PR.IR-02: Incident response activities are managed | Playbook defines roles, timelines, and escalation. Audit log provides evidence trail. Finding lifecycle tracked in database (discovery through disclosure). | P2, P3 | `docs/compliance/incident-response-playbook.md`, `migrations/versions/001_initial_schema.py:58-87` |
+
+---
+
+## DE: Detect
+
+The Detect function enables timely discovery of cybersecurity events.
+
+| Subcategory | Mantis Implementation | Principle | Evidence |
+|-------------|----------------------|-----------|----------|
+| DE.CM-01: Networks are monitored for potential cybersecurity events | Network egress restricted to allowlisted endpoints. iptables rules log dropped traffic. Inter-container communication disabled (`enable_icc=false`). | P1 | `scripts/setup-network.sh:38-40, 62-63` |
+| DE.CM-02: Physical environments are monitored | Gap -- not applicable at application level. | -- | N/A |
+| DE.CM-03: Personnel activity is monitored | Audit log records all human actions: review sign-offs, disclosure approvals, with timestamp and reviewer identity. | P3 | `harness/findings.py:241-251` (audit write on human review) |
+| DE.CM-06: External service provider activity is monitored | LLM API calls logged in audit: model, token counts, cost. Every LLM interaction recorded before execution. | P3, P6 | `harness/validator.py:75-89` (audit of validation call) |
+| DE.CM-09: Computing hardware and software are monitored | Container exit events logged with exit code, stdout length, and error details. Timeout detection with forced container kill. | P3 | `harness/dispatcher.py:145-157, 170-182` |
+| DE.AE-02: Potentially adverse events are analyzed | ASAN output parsed and classified by crash type and severity. Validation agent performs independent analysis. Three-question assessment framework. | -- | `harness/parser.py:150-202`, `harness/validator.py:16-37` |
+| DE.AE-03: Information is correlated from multiple sources | Parser combines agent JSON output with ASAN stderr. Validation agent cross-references ASAN consistency, reproduction plausibility, and security meaningfulness. | -- | `harness/parser.py:166-172` (multiple source correlation) |
+| DE.AE-06: Information on adverse events is provided to authorized staff | Findings enter human review queue ordered by severity. Reports include all context: description, reproduction, ASAN output, patch, agent reasoning, validation assessment. | P2, P7 | `harness/findings.py:15-63, 191-207` |
+| DE.AE-07: Cyber threat intelligence and other contextual information are integrated | Gap -- planned. No integration with external threat intelligence (NVD, CVE databases). See issue #25. | -- | N/A |
+| DE.AE-08: Incidents are declared based on criteria | Validation verdicts serve as incident declaration criteria: VALIDATE = confirmed incident, REJECT = non-incident, NEEDS_HUMAN_TRIAGE = requires human determination. | -- | `harness/validator.py:102-104` |
+
+---
+
+## RS: Respond
+
+The Respond function supports the ability to take action regarding a detected cybersecurity incident.
+
+| Subcategory | Mantis Implementation | Principle | Evidence |
+|-------------|----------------------|-----------|----------|
+| RS.MA-01: Incident response plan is executed | Incident response playbook provides step-by-step procedures for each severity tier. Four phases: Triage, Internal Review, Coordinated Disclosure, Post-Incident Review. | P2 | `docs/compliance/incident-response-playbook.md` |
+| RS.MA-02: Incident reports are triaged | Severity tier (1-5) provides automatic triage. Validation agent routes findings. Human review queue ordered by priority. | P7 | `harness/parser.py:82-91`, `harness/findings.py:191-207` |
+| RS.MA-03: Incidents are categorized | Crash taxonomy: heap-buffer-overflow, stack-buffer-overflow, use-after-free, use-after-return, null-dereference, memory-leak, global-buffer-overflow. Each mapped to severity tier with READ/WRITE distinction. | -- | `harness/parser.py:9-31` |
+| RS.MA-04: Incidents are escalated | Escalation matrix in playbook: Tier 5 = CISO + Legal + Eng Lead within 4 hours; Tier 4 = Security Lead + Eng Lead within 24 hours; Tier 1 = monthly report. | P2 | `docs/compliance/incident-response-playbook.md` |
+| RS.MA-05: Incidents are resolved | Human reviewer confirms finding, sets confirmed CVSS, approves/denies disclosure. Record updated in database with timestamp. Audit log entry written. | P2, P7 | `harness/findings.py:210-251` |
+| RS.AN-03: Analysis is performed to establish what took place | Agent reasoning recorded in findings. ASAN output provides deterministic crash evidence. Reproduction commands allow independent verification. Full audit trail available. | P3 | `harness/findings.py:15-63`, `harness/audit.py:39-88` |
+| RS.AN-06: Actions performed during investigation are recorded | Every action logged before execution (P3). Audit entries include sequence number, timestamp, actor, event type, and full payload. Hash chain ensures tamper evidence. | P3 | `harness/audit.py:39-88` |
+| RS.AN-07: Incident data and metadata are collected and preserved | All finding data preserved in Postgres: raw agent output, parsed metadata, validation results, human review decisions. Sensitive fields encrypted (P8). Audit log preserved separately. | P3, P8 | `migrations/versions/001_initial_schema.py:58-87`, `harness/findings.py:114-156` |
+| RS.AN-08: Incidents are analyzed for patterns | Gap -- partial. Individual findings analyzed. No cross-run pattern analysis or trend detection capability. See issue #28. | -- | N/A |
+| RS.CO-02: Internal stakeholders are notified of incidents | Gap -- partial. Findings appear in human review queue. No push notification system (email, Slack, PagerDuty). See issue #23. | P2 | `harness/findings.py:191-207` |
+| RS.CO-03: Information is shared with designated external stakeholders | P2 mandates human sign-off before any external communication. Coordinated disclosure follows 90+45 day timeline per incident response playbook. | P2 | `01-constitution.md:23-24`, `docs/compliance/incident-response-playbook.md` |
+| RS.MI-01: Incidents are contained | Container isolation prevents lateral movement. Exploit code encrypted at rest. No autonomous external transmission. Containers destroyed after use. | P1, P5, P8 | `harness/dispatcher.py:34-76`, `harness/crypto.py:13-18` |
+| RS.MI-02: Incidents are eradicated | Containers are ephemeral -- destroyed after each job (P5). tmpfs workspace cleared on exit. No persistent state to clean up. | P5 | `01-constitution.md:32-33`, `harness/dispatcher.py:34` |
+
+---
+
+## RC: Recover
+
+The Recover function supports timely return to normal operations to reduce the impact of a cybersecurity incident.
+
+| Subcategory | Mantis Implementation | Principle | Evidence |
+|-------------|----------------------|-----------|----------|
+| RC.RP-01: Recovery plan is executed | Container crash/timeout produces a failed-job record, not data loss (P5). Queue continues processing remaining jobs. Retry mechanism: failed containers retried once with different seed. | P5 | `01-constitution.md:32-33`, `02-specification.md:113-114` |
+| RC.RP-02: Recovery actions are selected and performed | Failed containers automatically retried once. Timeout containers killed and job marked. Spend limit reached pauses dispatch (does not cancel running work). | P5 | `harness/dispatcher.py:112-157` |
+| RC.RP-03: The integrity of backups and restored assets is verified | Audit log hash chain verification function validates integrity of recovered logs. `verify_chain()` returns the exact sequence number where corruption begins, if any. | P3 | `harness/audit.py:93-123` |
+| RC.RP-04: Critical functions and services are restored | Gap -- partial. No automated service recovery (container orchestration restart, database failover). Kubernetes deployment would provide this. See issue #29. | -- | N/A |
+| RC.RP-05: Recovery activities are verified | Audit chain verification provides integrity verification after recovery. Container re-execution capability allows re-running failed jobs. | P3 | `harness/audit.py:93-123` |
+| RC.CO-03: Recovery activities are communicated | Gap -- planned. No automated communication of recovery status. See issue #23. | -- | N/A |
+| RC.CO-04: Public updates on incident recovery are shared | P2 ensures no public communication without explicit human sign-off. Coordinated disclosure handles external communication timeline. | P2 | `01-constitution.md:23-24` |
+
+---
+
+## Summary: Principle-to-CSF Cross-Reference
+
+| Principle | CSF Functions Addressed |
+|-----------|------------------------|
+| P1 -- Isolation is absolute | PR (PR.AA-05, PR.DS-02), DE (DE.CM-01), RS (RS.MI-01) |
+| P2 -- Human review before external action | GV (GV.RR-01), RS (RS.CO-03, RS.MA-05), RC (RC.CO-04) |
+| P3 -- Every action logged before execution | GV (GV.RR-02), PR (PR.PS-04), DE (DE.CM-03, DE.CM-06), RS (RS.AN-06, RS.AN-07) |
+| P4 -- No credential persistence | PR (PR.AA-01), GV (GV.SC-02) |
+| P5 -- Containers ephemeral and disposable | PR (PR.DS-10, PR.PS-05), RS (RS.MI-02), RC (RC.RP-01) |
+| P6 -- Cost tracked in real time | GV (GV.RM-02), DE (DE.CM-06) |
+| P7 -- Tool never decides severity alone | GV (GV.RR-01), ID (ID.RA-05), RS (RS.MA-02) |
+| P8 -- Exploit code is contained | PR (PR.DS-01), RS (RS.MI-01, RS.AN-07) |
+
+---
+
+## Summary of Gaps
+
+| Gap | CSF Subcategory | Description | Planned Remediation |
+|-----|----------------|-------------|---------------------|
+| Enterprise risk management integration | GV.RM-03 | No ERM tool integration | Issue #24 |
+| Supply chain risk management | GV.SC-01 | No SBOM or dependency scanning | Issue #21 |
+| Identity authentication | PR.AA-02, PR.AA-03 | No user authentication system | Issue #18 |
+| Security training | PR.AT-01, PR.AT-02 | No training materials | Issue #19 |
+| Data backups | PR.DS-11 | No automated backup procedures | Issue #27 |
+| Threat intelligence integration | DE.AE-07 | No NVD/CVE integration | Issue #25 |
+| Cross-run pattern analysis | RS.AN-08 | No trend detection | Issue #28 |
+| Stakeholder notifications | RS.CO-02 | No push notifications | Issue #23 |
+| Automated service recovery | RC.RP-04 | No orchestration-level recovery | Issue #29 |

--- a/docs/compliance/threat-model.md
+++ b/docs/compliance/threat-model.md
@@ -1,0 +1,279 @@
+# Mantis Threat Model
+
+**Document version**: 1.0
+**Last updated**: 2026-04-25
+**Methodology**: STRIDE (Spoofing, Tampering, Repudiation, Information Disclosure, Denial of Service, Elevation of Privilege)
+**Scope**: The Mantis system itself -- not the target software it scans
+
+---
+
+## 1. System Overview
+
+Mantis is an autonomous vulnerability discovery harness that runs LLM-powered security research agents inside isolated Docker containers against AddressSanitizer-instrumented C/C++ binaries. The system consists of:
+
+- **Orchestrator** (Python 3.12+): CLI-driven pipeline controller running on the operator's host
+- **Worker containers** (Docker): Ephemeral, isolated environments running ReAct agent loops via litellm
+- **Redis**: Job queue and spend tracking (local dev) or Postgres (production)
+- **Postgres**: Findings store with encrypted sensitive columns (AES-256-GCM)
+- **Audit log**: Append-only SHA-3 hash-chained JSONL file on local filesystem
+- **LLM provider API**: External service (Anthropic, OpenAI, Google, or local Ollama)
+- **Network layer**: Docker bridge network with iptables egress rules
+
+---
+
+## 2. Asset Inventory
+
+| Asset | Type | Classification | Location | Integrity Mechanism |
+|-------|------|---------------|----------|-------------------|
+| Audit log (JSONL) | Data | Compliance | `{run_dir}/audit.jsonl` | SHA-3 hash chain (`harness/audit.py:81-83`) |
+| Findings store | Data | Internal/Restricted | Postgres `findings` table | AES-256-GCM for sensitive columns (`harness/crypto.py:13-18`) |
+| Exploit code / PoC | Data | Restricted | Postgres `reproduction_enc` column | AES-256-GCM encrypted (`harness/findings.py:125`) |
+| Worker containers | Compute | Ephemeral | Docker runtime | `--cap-drop ALL`, `no-new-privileges`, read-only rootfs |
+| LLM API connection | Network | Sensitive | Egress from containers | HTTPS only, iptables allowlist (`scripts/setup-network.sh:67-69`) |
+| Configuration (YAML) | Config | Internal | `harness.yaml` on operator host | No secrets in file; env vars override (`harness/config.py:37-96`) |
+| Encryption key (FINDINGS_ENC_KEY) | Secret | Critical | Environment variable | Base64-encoded, 32-byte validation (`harness/crypto.py:30-37`) |
+| API keys (ANTHROPIC_API_KEY, etc.) | Secret | Critical | Environment variables | Runtime injection only (P4), never in images or on disk |
+| Target source code | Data | External | Volume-mounted read-only | `:ro` mount prevents modification (`harness/dispatcher.py:44`) |
+| Pre-compiled ASAN binaries | Binary | Internal | Volume-mounted read-only | `:ro` mount, built in controlled environment |
+
+---
+
+## 3. Data Flow Diagram
+
+```
+                                    EXTERNAL
+                                 +-----------+
+                                 | LLM       |
+                                 | Provider  |
+                                 | API       |
+                                 +-----+-----+
+                                       | HTTPS :443
+                                       | (allowlisted IPs only)
+                                       |
++------------------+             +-----+-----+              +-----------+
+|                  |  dispatch   |           |  raw output  |           |
+|  Operator Host   +----------->+ Worker    +------------->+ ASAN      |
+|                  |  (docker   | Container |  (stdout)    | Parser    |
+|  - CLI           |   run)     | (N of M)  |              |           |
+|  - Config YAML   |            |           |              +-----+-----+
+|  - Audit Log     |<-----------+ - ReAct   |                    |
+|                  |  exit code | - bash    |              +-----+-----+
++--------+---------+  + stdout  | - litellm |              |           |
+         |                      +-----+-----+              | Validation|
+         |                            |                    | Agent     |
+         |                            | tmpfs              | (litellm) |
+         |                            | (destroyed         |           |
+         |                            |  on exit)          +-----+-----+
+         |                                                       |
+         |              +--------------------+                   |
+         +------------->+                    +<------------------+
+                        |  Postgres          |
+                        |  - runs            |
+                        |  - jobs            |
+                        |  - findings (enc)  |
+                        +--------------------+
+
+    +-------------------+
+    |  Redis             |
+    |  - job queue       |
+    |  - spend tracking  |
+    +-------------------+
+```
+
+**Data flows**:
+1. Operator -> Orchestrator: CLI commands, configuration
+2. Orchestrator -> Redis: Job enqueue, spend updates
+3. Orchestrator -> Docker: Container lifecycle (create, monitor, destroy)
+4. Container -> LLM API: Prompts and tool definitions (HTTPS)
+5. LLM API -> Container: Responses with tool calls
+6. Container -> Orchestrator: stdout (agent JSON), stderr (ASAN output)
+7. Orchestrator -> Audit Log: Every action before execution
+8. Orchestrator -> Postgres: Findings (sensitive fields encrypted)
+9. Orchestrator -> Filesystem: Human review reports (markdown)
+
+---
+
+## 4. STRIDE Analysis
+
+### 4.1 Spoofing
+
+| Asset / Component | Threat | Mitigation | Residual Risk |
+|-------------------|--------|-----------|---------------|
+| Human reviewer identity | Attacker impersonates a reviewer to approve disclosure of a finding | Reviewer identity recorded in audit log and database (`harness/findings.py:213`). Audit log hash chain prevents retroactive identity changes. | **Medium**. No authentication system verifies reviewer identity. The `reviewer` field is a string passed by the caller. An operator with database access could forge reviews. Mitigated in production by deploying behind an authenticated API gateway. |
+| LLM API endpoint | Man-in-the-middle replaces LLM API endpoint to feed malicious instructions to agents | HTTPS enforced (port 443 only, `scripts/setup-network.sh:67-69`). iptables rules restrict egress to specific resolved IPs. | **Low**. TLS certificate validation by litellm/requests prevents MITM. DNS spoofing could redirect to wrong IP, but TLS cert mismatch would cause connection failure. |
+| Worker container identity | Rogue container on the Docker network impersonates a legitimate worker | Inter-container communication disabled (`--icc=false`, `scripts/setup-network.sh:39`). Container names include job ID. Results collected via Docker stdout, not network. | **Low**. No inter-container network path exists. |
+| Orchestrator | Attacker gains access to operator host and runs unauthorized scans | Gap. No authentication for CLI access. Relies on OS-level access controls. | **Medium**. In production, the orchestrator should be behind an authenticated service layer. |
+
+### 4.2 Tampering
+
+| Asset / Component | Threat | Mitigation | Residual Risk |
+|-------------------|--------|-----------|---------------|
+| Audit log | Attacker modifies audit log to hide actions or forge compliance evidence | SHA-3 hash chain: each entry's `this_hash` covers full JSON including `prev_hash`. `verify_chain()` detects any modification (`harness/audit.py:93-123`). | **Low** for detection, **Medium** for prevention. The hash chain detects tampering but does not prevent it. An attacker with filesystem access could rewrite the entire log with a valid chain. Mitigation: ship audit entries to an external immutable store (e.g., governance platform, S3 with Object Lock). |
+| Findings database | Attacker modifies finding records to change severity, approval status, or exploit code | Sensitive fields encrypted with AES-256-GCM (`harness/crypto.py:13-18`). Modification of encrypted fields without the key produces authentication tag failure on decryption. | **Medium**. Unencrypted metadata fields (severity_tier, cvss_estimate, validation_verdict, human_reviewed) could be modified by anyone with database access. Postgres row-level security or application-level audit triggers would reduce this risk. |
+| Target source code | Agent modifies target source to hide vulnerabilities or inject backdoors | Source mounted read-only (`:ro` flag, `harness/dispatcher.py:44`). Agent cannot write to `/target/src`. | **Negligible**. Docker enforces read-only mount. |
+| Container image | Supply chain attack modifies worker Docker image to exfiltrate data | Images built from Dockerfile in repository. Base image `ubuntu:24.04` from Docker Hub. | **Medium**. No image signing or digest pinning. An attacker who compromises Docker Hub or the build pipeline could inject malicious code. Mitigation: pin base image by digest, sign images with cosign. |
+| LLM responses | LLM provider returns manipulated responses to cause false negatives (missed vulnerabilities) | Validation agent (Stage 5) provides independent second opinion. ASAN provides deterministic ground truth -- the LLM cannot fake ASAN output. | **Low**. ASAN is the oracle, not the LLM. The LLM guides exploration, but ASAN confirms crashes. A compromised LLM could miss vulnerabilities (false negatives) but cannot fabricate them (false positives are caught by validation + human review). |
+
+### 4.3 Repudiation
+
+| Asset / Component | Threat | Mitigation | Residual Risk |
+|-------------------|--------|-----------|---------------|
+| Human review actions | Reviewer denies having approved a disclosure | Audit log entry with reviewer name, timestamp, and hash chain (`harness/findings.py:241-251`). Database records `human_reviewer` and `reviewed_at`. | **Low**. Hash chain provides non-repudiation for the sequence of events. However, without digital signatures on individual entries, an attacker with full system access could theoretically rebuild the chain. |
+| Agent actions | Need to prove what the agent did or did not do | Every tool call and LLM response logged in audit before execution (P3, `harness/audit.py:39-88`). Worker stderr captures tool call details (`worker/agent/loop.py:82-91`). | **Low**. Comprehensive logging with hash chain provides strong evidence trail. |
+| Disclosure decisions | Regulatory inquiry about whether disclosure was properly authorized | `disclosure_approved` field with timestamp and reviewer in database (`migrations/versions/001_initial_schema.py:74`). Corresponding audit log entry. | **Low**. Dual recording (database + audit log) provides redundant evidence. |
+| Cost expenditure | Dispute about how much was spent on a scan run | Every LLM call records token counts and cost estimate in audit log. Redis tracks running spend total. | **Low**. Multiple independent cost records (audit log, Redis, LLM response metadata). |
+
+### 4.4 Information Disclosure
+
+| Asset / Component | Threat | Mitigation | Residual Risk |
+|-------------------|--------|-----------|---------------|
+| Exploit code / PoC | Leaked exploit code enables attackers to exploit the vulnerability before disclosure | AES-256-GCM encryption in Postgres (P8, `harness/crypto.py:13-18`). Never printed to stdout in plaintext (`01-constitution.md:40-41`). Container tmpfs destroyed on exit. | **Low** if encryption key is protected. **Critical** if key is leaked. The FINDINGS_ENC_KEY is the single point of failure for exploit code confidentiality. |
+| API keys | Leaked API keys enable unauthorized LLM usage or impersonation | Environment variable injection only (P4). Never in Docker images, config files, or audit log. `harness/dispatcher.py:51-54` passes keys via `-e` flag. | **Medium**. API keys exist in the process environment of running containers. A container escape or `/proc` filesystem read could expose them. Mitigated by `--cap-drop ALL` and `no-new-privileges`. |
+| ASAN output with vulnerability details | Detailed crash information leaks vulnerability details before responsible disclosure | ASAN output encrypted in findings store (`asan_output_enc` column). Raw agent output in Redis/job records may contain ASAN details in plaintext. | **Medium**. Job `result_raw` JSONB column in Postgres is not encrypted. It may contain ASAN output embedded in agent JSON. This is a gap -- `result_raw` should be encrypted or access-restricted. |
+| Audit log contents | Audit log may contain sensitive payload data (LLM prompts, finding details) | Audit log is a local file with OS-level access controls. No encryption of audit log contents. | **Medium**. Audit log payloads include event metadata but not full exploit code. However, finding validation payloads include verdicts and job IDs that could be correlated to findings. Access should be restricted to authorized personnel. |
+| LLM API traffic | Network interception of prompts/responses containing vulnerability analysis | HTTPS enforced for all LLM API traffic (`scripts/setup-network.sh:67-69`). TLS protects data in transit. | **Low**. Standard TLS protection. LLM provider has access to all prompts and responses -- this is inherent to the architecture. |
+
+### 4.5 Denial of Service
+
+| Asset / Component | Threat | Mitigation | Residual Risk |
+|-------------------|--------|-----------|---------------|
+| Worker containers | Resource exhaustion (memory, CPU, disk) | Memory limit: `--memory 4g` with no swap. CPU limit: `--cpus 2`. tmpfs size limits: `/tmp:size=4g`. Hard timeout: 1800 seconds with forced kill. | **Low**. Docker enforces resource limits. Timeout mechanism kills unresponsive containers (`harness/dispatcher.py:108-157`). |
+| LLM API | Rate limiting or outage prevents agent operation | Three retries with exponential backoff for validation calls (`harness/validator.py:60-73`). Agent loop handles API failures gracefully, returning `inconclusive` verdict. | **Medium**. LLM provider outage halts all scanning. No fallback provider configuration. Mitigation: configure multiple providers or use local Ollama as fallback. |
+| Redis queue | Queue flooding or Redis outage | Concurrency limit via asyncio.Semaphore (`harness/dispatcher.py:216`). Spend limit checks before each dispatch. | **Medium**. Redis is a single point of failure for job dispatch in local dev. Production should use Postgres or Redis with replication. |
+| Audit log filesystem | Disk full prevents audit writes, which blocks all operations (P3) | Audit write failure causes run failure (`01-constitution.md:26-27`). This is by design -- silent log failure would violate P3. | **Low** for data integrity, **Medium** for availability. A full disk stops all operations. Operators should monitor disk space and configure log rotation/archival. |
+| Postgres database | Database outage prevents finding storage | asyncpg connections are per-operation (open, execute, close). No connection pooling. | **Medium**. No connection pooling or retry logic for database operations. A transient Postgres outage during finding storage could lose results. |
+| Operator host | Attacker floods CLI with scan requests | No rate limiting on CLI invocation. Spend limits cap financial exposure. | **Low**. CLI is local; attacker needs host access, which is a larger compromise. |
+
+### 4.6 Elevation of Privilege
+
+| Asset / Component | Threat | Mitigation | Residual Risk |
+|-------------------|--------|-----------|---------------|
+| Worker container escape | Agent exploits container runtime vulnerability to escape to host | `--cap-drop ALL`: all Linux capabilities removed. `--security-opt no-new-privileges`: prevents suid/sgid escalation. Non-root user (UID 1001, `worker/Dockerfile:33-34`). Read-only root filesystem. tmpfs-only writable paths. | **Low** but **Critical impact**. Container escape would grant host access. Defense in depth (multiple layers), but Docker escape vulnerabilities do occur. Kubernetes with gVisor or Kata Containers would add a stronger isolation boundary. |
+| Agent prompt injection | LLM manipulated into executing unauthorized commands via crafted input in target source code | Agent has `bash()` and `read_file()` tools only (`worker/agent/tools.py:5-37`). No network tools, no file write to persistent storage. Workspace is tmpfs. Container network blocks all non-API egress. | **Medium**. The agent has bash access by design -- it needs it for security research. A prompt injection in the target code could cause the agent to execute arbitrary bash within the container, but the container's security boundary limits impact. The agent cannot exfiltrate data (no outbound except API), modify source (read-only), or persist state (tmpfs). |
+| Agent privilege within container | Agent escalates from non-root to root inside container | `no-new-privileges` security option. No setuid binaries (capabilities dropped). Non-root user by default. | **Low**. Standard Linux privilege escalation mitigated. Kernel exploits are the remaining vector, addressed by keeping Docker and kernel updated. |
+| Database access | Attacker with Postgres access modifies findings or approval status | Gap -- partial. No row-level security. No database audit trail beyond application-level audit log. Connection authenticated by password (env var). | **Medium**. Anyone with `POSTGRES_PASSWORD` can modify any record. Postgres RLS and audit triggers would improve this. |
+| Orchestrator escalation | Attacker with operator access gains access to encrypted findings | Encryption key (`FINDINGS_ENC_KEY`) must be in the environment to operate. Operator with env access can decrypt findings. | **Medium**. This is inherent -- the operator must be trusted. In production, use a secrets manager (Vault, AWS Secrets Manager) with access logging. |
+
+---
+
+## 5. Attack Trees
+
+### 5.1 Highest Risk: LLM Provider Compromise
+
+```
+Goal: Exfiltrate vulnerability data via compromised LLM provider
+|
++-- 1. Compromise LLM provider API
+|   |
+|   +-- 1a. Compromise provider infrastructure (external, out of scope)
+|   +-- 1b. Steal API key from operator environment
+|       |
+|       +-- 1b.i. Access operator host (OS compromise)
+|       +-- 1b.ii. Read from container /proc (requires container escape)
+|       +-- 1b.iii. Intercept docker run command (requires host access)
+|
++-- 2. Extract vulnerability information from API traffic
+|   |
+|   +-- 2a. LLM provider logs contain full prompts/responses
+|   |   (Mitigation: select provider with data retention policy)
+|   +-- 2b. Provider-side employee accesses conversation data
+|       (Mitigation: contractual controls, SOC2 attestation from provider)
+|
++-- 3. Manipulate agent behavior via compromised API
+    |
+    +-- 3a. Return false negatives (miss real vulns)
+    |   (Mitigation: ASAN is ground truth, not LLM)
+    +-- 3b. Return instructions to exfiltrate via API calls
+        (Mitigation: agent sends prompts to API; data in prompts IS the risk)
+```
+
+**Assessment**: The LLM provider inherently sees all prompts and responses. This includes target source code, ASAN output, and vulnerability analysis. This is a fundamental architectural property, not a bug. Mitigation: choose providers with strong data handling policies, consider local models (Ollama) for highly sensitive targets, and use the data classification system to decide what targets are appropriate for which providers.
+
+### 5.2 Container Escape
+
+```
+Goal: Escape worker container to access host system
+|
++-- 1. Exploit Docker runtime vulnerability
+|   |
+|   +-- 1a. Kernel exploit from within container
+|   |   (Mitigation: --cap-drop ALL, no-new-privileges, non-root)
+|   +-- 1b. Docker daemon exploit via API
+|   |   (Mitigation: no Docker socket mounted in container)
+|   +-- 1c. Exploit in volume mount handling
+|       (Mitigation: read-only mounts, tmpfs only writable)
+|
++-- 2. Exploit agent to perform escape
+|   |
+|   +-- 2a. Prompt injection in target source causes agent to
+|   |   attempt escape techniques
+|   |   (Mitigation: capabilities dropped, no suid, no network)
+|   +-- 2b. Agent discovers and exploits 0-day in container runtime
+|       (Mitigation: agent has bash but limited tools; no persistent network)
+|
++-- 3. Exploit shared resources
+    |
+    +-- 3a. Exploit via /proc or /sys filesystem
+    |   (Mitigation: default Docker seccomp profile, no-new-privileges)
+    +-- 3b. Exploit via mounted volumes
+        (Mitigation: source and binaries read-only, workspace is tmpfs)
+```
+
+**Assessment**: Container escape is the highest-impact local threat. Multiple layers of defense are in place (capability drop, non-root, read-only filesystem, no Docker socket, network restriction). The residual risk is kernel-level container escape vulnerabilities, which are rare but have occurred (CVE-2024-21626, CVE-2019-5736). Production deployments should use gVisor, Kata Containers, or equivalent sandbox runtime.
+
+### 5.3 Audit Log Manipulation
+
+```
+Goal: Tamper with audit log to hide unauthorized actions
+|
++-- 1. Modify existing entries
+|   |
+|   +-- 1a. Edit a single entry
+|   |   (Detected by: hash chain verification, verify_chain())
+|   +-- 1b. Rewrite entire log with valid new chain
+|       (Mitigation: ship entries to external immutable store)
+|
++-- 2. Prevent new entries from being written
+|   |
+|   +-- 2a. Fill disk to block audit writes
+|   |   (Effect: run fails, P3 enforced -- no silent failure)
+|   +-- 2b. Corrupt audit file
+|       (Effect: next write detects corruption on read)
+|
++-- 3. Delete audit log
+    |
+    +-- 3a. Remove file from filesystem
+        (Mitigation: OS file permissions + external backup)
+```
+
+**Assessment**: The hash chain provides tamper detection but not tamper prevention. For regulated deployments, audit entries should be forwarded to an external immutable store in real time. The specification notes this as a "one-day integration" (`02-specification.md:374-375`).
+
+---
+
+## 6. Residual Risk Register
+
+| ID | Risk | Likelihood | Impact | Current Mitigations | Residual Status | Accepted? |
+|----|------|-----------|--------|---------------------|-----------------|-----------|
+| R1 | LLM provider sees all vulnerability analysis data | Certain (by design) | High | Provider selection, data classification, local model option | **High** | Accepted with controls. Operators must evaluate provider trust before scanning sensitive targets. |
+| R2 | Container escape via kernel vulnerability | Very Low | Critical | `--cap-drop ALL`, `no-new-privileges`, non-root, read-only rootfs, network isolation | **Low** | Accepted for dev. Production should use gVisor/Kata. |
+| R3 | Audit log rewritten with valid chain | Low | High | Hash chain detects single-entry tampering. Full rewrite requires filesystem access. | **Medium** | Not accepted. External immutable store integration required for production. |
+| R4 | FINDINGS_ENC_KEY compromised | Low | Critical | Env-var only, not on disk. Access requires host compromise. | **Medium** | Accepted with monitoring. Production should use secrets manager with access logging. |
+| R5 | API key leaked from container environment | Low | High | Keys in env vars only, capability drop limits `/proc` access | **Low** | Accepted. Short-lived API keys or per-container tokens recommended for production. |
+| R6 | Reviewer identity spoofed (no authentication) | Medium | High | Audit log records identity, but no verification | **High** | Not accepted for production. Authentication system required (issue #18). |
+| R7 | `result_raw` JSONB column contains unencrypted vulnerability details | Certain (by design) | Medium | Database access controls | **Medium** | Not accepted. `result_raw` should be encrypted or redacted (issue #30). |
+| R8 | Prompt injection in target source | Medium | Low | Container isolation limits blast radius, ASAN is ground truth | **Low** | Accepted. Agent needs bash access; container boundary is the control. |
+| R9 | Supply chain compromise of container base image | Very Low | Critical | Dockerfile in version control, reproducible builds | **Low** | Accepted with recommendation to pin base image by digest. |
+| R10 | Redis single point of failure | Medium | Medium | Spend limits cap exposure. Jobs can be re-enqueued. | **Medium** | Accepted for dev. Production should use Redis replication or Postgres queue. |
+| R11 | Database operations lack retry logic | Medium | Low | Per-operation connections, asyncpg error handling | **Medium** | Accepted. Add retry logic with exponential backoff (issue #31). |
+| R12 | No automated backup for findings store | Medium | High | Manual Postgres backup available | **High** | Not accepted for production. Automated backup required (issue #27). |
+
+---
+
+## 7. Review Schedule
+
+This threat model should be reviewed:
+- After any significant architecture change
+- After any container runtime CVE affecting Docker
+- After adding new data flows or external integrations
+- At minimum annually
+- After any security incident involving the Mantis system itself


### PR DESCRIPTION
## Summary

- Add NIST SP 800-218 (SSDF) compliance mapping covering all four practice groups (PO, PS, PW, RV) with evidence file paths
- Add NIST CSF 2.0 mapping across all six functions (Govern, Identify, Protect, Detect, Respond, Recover) cross-referenced with P1-P8 principles
- Add formal STRIDE threat model with attack trees for LLM provider compromise, container escape, and audit log manipulation, plus a residual risk register
- Add data retention and destruction policy covering FINRA/SOX 7-year retention, GDPR/CCPA data minimization, cryptographic erasure procedures, and key management
- Add incident response playbook with four phases (Triage, Internal Review, Coordinated Disclosure, Post-Incident Review), escalation matrix by severity tier, and CVE assignment process

All documents reference actual codebase file paths as evidence and honestly identify gaps with planned remediation issue numbers.

## Test plan

- [ ] Verify all referenced file paths (e.g., `harness/audit.py:39-88`) exist and match the described functionality
- [ ] Verify P1-P8 principle references align with `01-constitution.md`
- [ ] Review SSDF gap analysis for completeness
- [ ] Review threat model residual risk register for accuracy
- [ ] Confirm data retention periods meet organizational regulatory requirements
- [ ] Confirm escalation matrix timelines are operationally feasible

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)