### PR TITLE
Fix hallucinated action SHAs in build-image workflow

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -41,10 +41,10 @@ jobs:
           persist-credentials: false
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Build worker image
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198571cfb76f00 # v6.18.0
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: worker
           file: worker/Dockerfile


### PR DESCRIPTION
## Summary
- `docker/setup-buildx-action` and `docker/build-push-action` had incorrect commit SHAs (hallucinated by subagent)
- Updated to verified tags: setup-buildx v4.0.0, build-push v7.1.0
- Same class of bug as the fix already pushed to PR #23

## Test plan
- [ ] `Docker build (worker)` check passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)