### PR TITLE
[codex] Wire one-time prebuild path to configured sanitizers

### DIFF
--- a/harness/cli.py
+++ b/harness/cli.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import click
 
 from harness.audit import AuditLog, verify_chain
+from harness.sanitizers import build_sanitizer_flags
 
 
 @click.group()
@@ -99,8 +100,8 @@ def _clone_repo(cfg, run_dir: Path) -> Path:
     return repo_path
 
 
-def _build_asan_binaries(cfg, repo_path: Path, bin_dir: Path, run_id: str, audit: AuditLog | None = None) -> None:
-    """Run the ASAN builder container once and collect binaries into *bin_dir*.
+def _build_sanitized_binaries(cfg, repo_path: Path, bin_dir: Path, run_id: str, audit: AuditLog | None = None) -> None:
+    """Run the builder container once and collect sanitized binaries into *bin_dir*.
 
     Raises ``SystemExit(1)`` if the build fails.
     """
@@ -108,8 +109,10 @@ def _build_asan_binaries(cfg, repo_path: Path, bin_dir: Path, run_id: str, audit
 
     repo_real = os.path.realpath(str(repo_path))
     bin_real = os.path.realpath(str(bin_dir))
+    sanitizer_flags = build_sanitizer_flags(cfg.sanitizers)
+    sanitizer_list = ",".join(sanitizer_flags.sanitizers)
 
-    click.echo(f"Building {cfg.project_name} with ASAN...")
+    click.echo(f"Building {cfg.project_name} with sanitizers: {sanitizer_list}...")
 
     cmd = [
         "docker",
@@ -131,6 +134,12 @@ def _build_asan_binaries(cfg, repo_path: Path, bin_dir: Path, run_id: str, audit
         f"BINARY_NAME={cfg.binary_name}",
         "-e",
         f"CONFIGURE_FLAGS={cfg.configure_flags}",
+        "-e",
+        f"SANITIZERS={sanitizer_list}",
+        "-e",
+        f"FULL_CFLAGS={sanitizer_flags.cflags}",
+        "-e",
+        f"FULL_LDFLAGS={sanitizer_flags.ldflags}",
         "--entrypoint",
         "/bin/bash",
         cfg.worker_image,
@@ -143,7 +152,11 @@ def _build_asan_binaries(cfg, repo_path: Path, bin_dir: Path, run_id: str, audit
             run_id=run_id,
             event_type="build_start",
             actor="orchestrator",
-            payload={"image": cfg.worker_image, "bin_dir": str(bin_dir)},
+            payload={
+                "image": cfg.worker_image,
+                "bin_dir": str(bin_dir),
+                "sanitizers": list(sanitizer_flags.sanitizers),
+            },
         )
 
     result = subprocess.run(cmd, capture_output=True, text=True)
@@ -178,7 +191,7 @@ def _build_asan_binaries(cfg, repo_path: Path, bin_dir: Path, run_id: str, audit
 @cli.command()
 @click.option("--config", "config_path", default="./harness.yaml", help="Path to harness.yaml")
 def build(config_path: str):
-    """Compile target with ASAN in a single container. Saves binaries for worker reuse."""
+    """Compile target with configured sanitizers in a single container. Saves binaries for worker reuse."""
     os.environ.setdefault("HARNESS_CONFIG", config_path)
     from harness.config import Config
 
@@ -191,7 +204,7 @@ def build(config_path: str):
 
     repo_path = _clone_repo(cfg, run_dir)
 
-    _build_asan_binaries(cfg, repo_path, bin_dir, run_id)
+    _build_sanitized_binaries(cfg, repo_path, bin_dir, run_id)
 
     click.echo(f"\nBin dir: {bin_dir}")
     click.echo(f"Run ID: {run_id}")
@@ -207,8 +220,12 @@ cd /tmp/src
 git submodule update --init --recursive 2>/dev/null || true
 
 export CC=clang
-export CFLAGS="-fsanitize=address -g -O1 -fno-omit-frame-pointer -fPIC"
-export LDFLAGS="-fsanitize=address"
+export SANITIZERS="${SANITIZERS:-asan}"
+export CFLAGS="${FULL_CFLAGS}"
+export LDFLAGS="${FULL_LDFLAGS}"
+
+echo "=== active sanitizers: ${SANITIZERS} ===" >&2
+echo "=== sanitize flags: ${CFLAGS} / ${LDFLAGS} ===" >&2
 
 if [ -n "${CONFIGURE_FLAGS:-}" ]; then
     CONF_CMD="./configure $CONFIGURE_FLAGS"
@@ -277,7 +294,7 @@ def run(config_path: str, bin_dir: str | None):
     if bin_dir is None:
         auto_bin_dir = run_dir / "bin"
         auto_bin_dir.mkdir(exist_ok=True)
-        _build_asan_binaries(cfg, repo_path, auto_bin_dir, run_id, audit=audit)
+        _build_sanitized_binaries(cfg, repo_path, auto_bin_dir, run_id, audit=audit)
         bin_dir = str(auto_bin_dir)
         click.echo(f"  Auto-built binaries: {bin_dir}")
 

--- a/harness/config.py
+++ b/harness/config.py
@@ -7,8 +7,10 @@ from pathlib import Path
 from typing import Any
 
 import yaml
-from pydantic import Field
+from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings, PydanticBaseSettingsSource, SettingsConfigDict
+
+from harness.sanitizers import validate_sanitizers
 
 
 class YamlSettingsSource(PydanticBaseSettingsSource):
@@ -89,6 +91,11 @@ class Config(BaseSettings):
     # Secrets — API keys are read from env vars by litellm automatically
     # (ANTHROPIC_API_KEY, OPENAI_API_KEY, GOOGLE_API_KEY, etc.)
     findings_enc_key: str | None = Field(default=None, alias="FINDINGS_ENC_KEY")
+
+    @field_validator("sanitizers")
+    @classmethod
+    def _validate_sanitizers(cls, value: list[str]) -> list[str]:
+        return validate_sanitizers(value)
 
     @classmethod
     def settings_customise_sources(cls, settings_cls, **kwargs):

--- a/harness/sanitizers.py
+++ b/harness/sanitizers.py
@@ -1,0 +1,74 @@
+"""Sanitizer validation and compiler flag generation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+SUPPORTED_SANITIZERS = {"asan", "ubsan", "msan", "tsan"}
+
+
+@dataclass(frozen=True)
+class SanitizerBuildFlags:
+    sanitizers: tuple[str, ...]
+    sanitize_flag: str
+    cflags: str
+    ldflags: str
+
+
+def validate_sanitizers(sanitizers: list[str]) -> list[str]:
+    """Validate configured sanitizers and return normalized order-preserving list."""
+    if not sanitizers:
+        raise ValueError("sanitizers must contain at least one entry")
+
+    normalized: list[str] = []
+    for sanitizer in sanitizers:
+        if sanitizer not in SUPPORTED_SANITIZERS:
+            supported = ", ".join(sorted(SUPPORTED_SANITIZERS))
+            raise ValueError(f"unsupported sanitizer '{sanitizer}'; supported: {supported}")
+        if sanitizer not in normalized:
+            normalized.append(sanitizer)
+
+    selected = set(normalized)
+    if "asan" in selected and "msan" in selected:
+        raise ValueError("invalid sanitizer combination: asan and msan cannot be combined")
+    if "asan" in selected and "tsan" in selected:
+        raise ValueError("invalid sanitizer combination: asan and tsan cannot be combined")
+    if "msan" in selected and "tsan" in selected:
+        raise ValueError("invalid sanitizer combination: msan and tsan cannot be combined")
+
+    return normalized
+
+
+def build_sanitizer_flags(sanitizers: list[str]) -> SanitizerBuildFlags:
+    """Generate compiler/linker flags for the configured sanitizer set."""
+    normalized = validate_sanitizers(sanitizers)
+
+    fsanitize_parts: list[str] = []
+    cflag_parts: list[str] = []
+    ldflag_parts: list[str] = []
+
+    for sanitizer in normalized:
+        if sanitizer == "asan":
+            fsanitize_parts.append("address")
+        elif sanitizer == "ubsan":
+            fsanitize_parts.append("undefined")
+            cflag_parts.append("-fno-sanitize-recover=all")
+        elif sanitizer == "msan":
+            fsanitize_parts.append("memory")
+            cflag_parts.append("-fPIE")
+            ldflag_parts.append("-pie")
+        elif sanitizer == "tsan":
+            fsanitize_parts.append("thread")
+
+    sanitize_flag = f"-fsanitize={','.join(fsanitize_parts)}"
+    cflags = " ".join(
+        part for part in [sanitize_flag, "-g", "-O1", "-fno-omit-frame-pointer", "-fPIC", *cflag_parts] if part
+    )
+    ldflags = " ".join(part for part in [sanitize_flag, *ldflag_parts] if part)
+
+    return SanitizerBuildFlags(
+        sanitizers=tuple(normalized),
+        sanitize_flag=sanitize_flag,
+        cflags=cflags,
+        ldflags=ldflags,
+    )

--- a/tests/unit/test_cli_build.py
+++ b/tests/unit/test_cli_build.py
@@ -1,0 +1,48 @@
+"""Tests for builder command sanitizer wiring."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+
+def test_build_sanitized_binaries_passes_multi_sanitizer_env(tmp_path: Path):
+    from harness.cli import _build_sanitized_binaries
+
+    repo_path = tmp_path / "repo"
+    repo_path.mkdir()
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    built_binary = bin_dir / "demo-bin"
+    built_binary.write_text("x")
+
+    cfg = SimpleNamespace(
+        project_name="demo",
+        worker_memory_gb=4,
+        worker_cpus=2,
+        binary_name="demo-bin",
+        configure_flags="",
+        worker_image="vuln-harness-worker:latest",
+        sanitizers=["asan", "ubsan"],
+    )
+
+    seen_cmd: list[str] = []
+
+    class Result:
+        returncode = 0
+        stderr = ""
+
+    def fake_run(cmd, capture_output, text):
+        seen_cmd.extend(cmd)
+        return Result()
+
+    with patch("subprocess.run", side_effect=fake_run):
+        _build_sanitized_binaries(cfg, repo_path, bin_dir, "run-123")
+
+    assert "SANITIZERS=asan,ubsan" in seen_cmd
+    cflags_entry = next(part for part in seen_cmd if part.startswith("FULL_CFLAGS="))
+    ldflags_entry = next(part for part in seen_cmd if part.startswith("FULL_LDFLAGS="))
+    assert "-fsanitize=address,undefined" in cflags_entry
+    assert "-fno-sanitize-recover=all" in cflags_entry
+    assert "-fsanitize=address,undefined" in ldflags_entry

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -109,3 +109,23 @@ def test_multi_sanitizers(tmp_path: Path, monkeypatch):
 
     cfg = Config()
     assert cfg.sanitizers == ["asan", "ubsan"]
+
+
+def test_invalid_sanitizer_combination_raises(tmp_path: Path, monkeypatch):
+    """Invalid sanitizer combinations fail fast during config load."""
+    data = {
+        "repo_url": "https://github.com/test/repo",
+        "binary_name": "testbin",
+        "project_name": "testproject",
+        "project_description": "A test project",
+        "postgres_url": "postgresql://localhost:5432/test",
+        "sanitizers": ["asan", "msan"],
+    }
+    p = tmp_path / "harness.yaml"
+    p.write_text(yaml.dump(data))
+    monkeypatch.setenv("HARNESS_CONFIG", str(p))
+
+    from harness.config import Config
+
+    with pytest.raises(ValueError, match="asan and msan"):
+        Config()

--- a/tests/unit/test_sanitizers.py
+++ b/tests/unit/test_sanitizers.py
@@ -1,0 +1,56 @@
+"""Tests for sanitizer validation and flag generation."""
+
+from __future__ import annotations
+
+import pytest
+
+from harness.sanitizers import build_sanitizer_flags, validate_sanitizers
+
+
+def test_build_flags_for_asan():
+    flags = build_sanitizer_flags(["asan"])
+    assert flags.sanitize_flag == "-fsanitize=address"
+    assert "-fno-omit-frame-pointer" in flags.cflags
+    assert flags.ldflags == "-fsanitize=address"
+
+
+def test_build_flags_for_asan_ubsan():
+    flags = build_sanitizer_flags(["asan", "ubsan"])
+    assert flags.sanitize_flag == "-fsanitize=address,undefined"
+    assert "-fno-sanitize-recover=all" in flags.cflags
+    assert flags.ldflags == "-fsanitize=address,undefined"
+
+
+def test_build_flags_for_msan():
+    flags = build_sanitizer_flags(["msan"])
+    assert flags.sanitize_flag == "-fsanitize=memory"
+    assert "-fPIE" in flags.cflags
+    assert "-pie" in flags.ldflags
+
+
+def test_build_flags_for_tsan():
+    flags = build_sanitizer_flags(["tsan"])
+    assert flags.sanitize_flag == "-fsanitize=thread"
+    assert flags.ldflags == "-fsanitize=thread"
+
+
+@pytest.mark.parametrize(
+    ("sanitizers", "message"),
+    [
+        (["asan", "msan"], "asan and msan"),
+        (["asan", "tsan"], "asan and tsan"),
+        (["msan", "tsan"], "msan and tsan"),
+    ],
+)
+def test_invalid_sanitizer_combinations_raise(sanitizers: list[str], message: str):
+    with pytest.raises(ValueError, match=message):
+        validate_sanitizers(sanitizers)
+
+
+def test_unknown_sanitizer_raises():
+    with pytest.raises(ValueError, match="unsupported sanitizer"):
+        validate_sanitizers(["foo"])
+
+
+def test_duplicate_sanitizers_are_deduplicated():
+    assert validate_sanitizers(["asan", "ubsan", "asan"]) == ["asan", "ubsan"]


### PR DESCRIPTION
## Summary

- wire the one-time prebuild path to `config.sanitizers` instead of hardcoding ASAN
- add shared sanitizer validation and compiler/linker flag generation in `harness/sanitizers.py`
- validate invalid sanitizer combinations at config load time
- pass `SANITIZERS`, `FULL_CFLAGS`, and `FULL_LDFLAGS` into the builder container
- add focused unit tests for sanitizer flags, builder wiring, and invalid config combinations

## Why

The worker compile path already supported multiple sanitizers via `SANITIZERS`, but the one-time prebuild path used by `vuln-harness build` and auto-build-in-`run` was still hardcoded to `-fsanitize=address`.

That made the implementation inconsistent:
- worker-local compilation could use UBSan / MSan / TSan
- precompiled shared binaries could only use ASAN

This PR closes that gap so the prebuild path reflects the configured sanitizer set and matches worker expectations.

## Impact

- `build` and auto-build-in-`run` now honor `sanitizers` from config
- invalid combinations fail fast with a clear error
- audit metadata for build start now includes the configured sanitizer set

## Validation

- `pytest tests/unit -q`
- `ruff check harness/cli.py harness/config.py harness/sanitizers.py tests/unit/test_sanitizers.py tests/unit/test_cli_build.py tests/unit/test_config.py`

## Related

- Closes #34
- PR #25 tracks the documentation follow-up once this implementation gap is resolved