### PR TITLE
feat: extract agent telemetry (turns, tokens, cost) in parser

### DIFF
--- a/harness/parser.py
+++ b/harness/parser.py
@@ -101,6 +101,11 @@ class ParsedFinding:
     agent_reasoning: str | None
     description: str | None
     raw_agent_output: dict
+    # Agent telemetry (None if not available — backward compatible)
+    turns_used: int | None = None
+    agent_cost_usd: float | None = None
+    agent_input_tokens: int | None = None
+    agent_output_tokens: int | None = None
 
 
 def _detect_vuln_type(asan_text: str) -> str | None:
@@ -243,4 +248,8 @@ def parse_result(
         agent_reasoning=agent_json.get("reasoning"),
         description=agent_json.get("description"),
         raw_agent_output=agent_json,
+        turns_used=agent_json.get("turns_used"),
+        agent_cost_usd=agent_json.get("cost_usd"),
+        agent_input_tokens=agent_json.get("input_tokens"),
+        agent_output_tokens=agent_json.get("output_tokens"),
     )

--- a/tests/fixtures/agent_output_with_telemetry.json
+++ b/tests/fixtures/agent_output_with_telemetry.json
@@ -1,0 +1,17 @@
+{
+  "verdict": "found",
+  "vuln_type": "heap-buffer-overflow",
+  "file": "util/gif2rgb.c",
+  "line": 293,
+  "function": "DumpScreen2RGB",
+  "description": "OOB read via palette index",
+  "asan_output": "ERROR: AddressSanitizer: heap-buffer-overflow on address 0x502000000288\nREAD of size 1 at 0x502000000288 thread T0\n    #0 in DumpScreen2RGB /tmp/src/util/gif2rgb.c:293:45",
+  "reproduction": "python3 -c 'print(\"trigger\")' | gif2rgb",
+  "candidate_patch": "add bounds check on GifRow[j]",
+  "confidence": "high",
+  "reasoning": "ASAN confirms heap OOB read past palette allocation",
+  "turns_used": 12,
+  "cost_usd": 0.0234,
+  "input_tokens": 15420,
+  "output_tokens": 3891
+}

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -194,6 +194,39 @@ def test_tsan_data_race(tsan_output: str):
     assert 5.0 <= finding.cvss_estimate <= 7.5
 
 
+def test_telemetry_fields_extracted():
+    agent = json.loads(Path("tests/fixtures/agent_output_with_telemetry.json").read_text())
+    stdout = json.dumps(agent)
+    finding = parse_result(stdout, "", job_id="j1", run_id="r1")
+    assert finding is not None
+    assert finding.turns_used == 12
+    assert finding.agent_cost_usd == 0.0234
+    assert finding.agent_input_tokens == 15420
+    assert finding.agent_output_tokens == 3891
+
+
+def test_telemetry_fields_default_when_missing():
+    """Backward compat: old agent output without telemetry still parses."""
+    agent = {
+        "verdict": "found",
+        "vuln_type": "heap-buffer-overflow",
+        "file": "x.c",
+        "line": 1,
+        "function": "main",
+        "description": "test",
+        "asan_output": "ERROR: AddressSanitizer: heap-buffer-overflow\nREAD of size 1\n    #0 in main x.c:1",
+    }
+    stdout = json.dumps(agent)
+    finding = parse_result(stdout, "", job_id="j1", run_id="r1")
+    assert finding is not None
+    assert finding.turns_used is None
+    assert finding.agent_cost_usd is None
+    assert finding.agent_input_tokens is None
+    assert finding.agent_output_tokens is None
+    assert finding.vuln_type == "heap-buffer-overflow"
+    assert finding.file == "x.c"
+
+
 def test_asan_still_works_with_multi_sanitizer_patterns(sample_asan: str):
     """Regression: existing ASAN output still parses correctly after adding new patterns."""
     agent = {


### PR DESCRIPTION
## Summary
- Add 4 optional telemetry fields to `ParsedFinding` dataclass: `turns_used`, `agent_cost_usd`, `agent_input_tokens`, `agent_output_tokens`
- Extract these fields from agent JSON output in `parse_result()` (mapped from `turns_used`, `cost_usd`, `input_tokens`, `output_tokens`)
- Fields default to `None` for full backward compatibility with older agent output

## Test plan
- [x] `test_telemetry_fields_extracted` — verifies all 4 fields are correctly extracted from fixture with telemetry data
- [x] `test_telemetry_fields_default_when_missing` — verifies backward compat: old agent output without telemetry fields still parses, all 4 fields default to `None`
- [x] All 92 existing unit tests continue to pass
- [x] ruff lint clean on changed files

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)