### PR TITLE
feat: add benchmark module with metric extraction and aggregation

### DIFF
--- a/harness/benchmark.py
+++ b/harness/benchmark.py
@@ -1,0 +1,135 @@
+"""Benchmark metrics extraction, aggregation, and comparison table generation."""
+
+from __future__ import annotations
+
+import json
+import re
+import statistics
+from pathlib import Path
+
+MODEL_PATTERN = re.compile(r"^[a-z][a-z0-9_-]*/[a-zA-Z0-9._:-]+$")
+
+
+def validate_model_string(model: str) -> bool:
+    """Validate a litellm model string matches provider/model format.
+
+    Rejects empty strings, strings > 100 chars, and non-matching patterns.
+    """
+    return bool(model) and len(model) <= 100 and bool(MODEL_PATTERN.match(model))
+
+
+def extract_run_metrics(audit_path: Path) -> dict:
+    """Extract benchmark metrics from a single run's audit log.
+
+    Handles both old-format (no telemetry) and new-format audit logs gracefully.
+    """
+    events = []
+    with open(audit_path) as f:
+        for line in f:
+            stripped = line.strip()
+            if stripped:
+                events.append(json.loads(stripped))
+
+    jobs_dispatched = 0
+    findings_count = 0
+    validated_count = 0
+    rejected_count = 0
+    total_wall_clock = 0.0
+    total_worker_cost = 0.0
+    total_validation_cost = 0.0
+    total_input_tokens = 0
+    total_output_tokens = 0
+    turn_counts: list[float] = []
+
+    for event in events:
+        et = event["event_type"]
+        payload = event.get("payload", {})
+
+        if et == "job_dispatch":
+            jobs_dispatched += 1
+
+        elif et == "container_exit":
+            total_wall_clock += payload.get("wall_clock_seconds", 0.0)
+            turns = payload.get("turns_used")
+            if turns is not None:
+                turn_counts.append(turns)
+            total_worker_cost += payload.get("cost_usd", 0.0)
+            total_input_tokens += payload.get("input_tokens", 0)
+            total_output_tokens += payload.get("output_tokens", 0)
+            # Only count as finding if verdict is "found" (not timeout, not not_found)
+            if payload.get("verdict") == "found":
+                findings_count += 1
+
+        elif et == "llm_call" and payload.get("stage") == "validation":
+            total_validation_cost += payload.get("cost_usd", 0.0)
+
+        elif et == "finding_validated":
+            verdict = payload.get("verdict", "")
+            if verdict == "VALIDATE":
+                validated_count += 1
+            elif verdict == "REJECT":
+                rejected_count += 1
+
+    total_judged = validated_count + rejected_count
+    fp_rate = (rejected_count / total_judged * 100) if total_judged > 0 else 0.0
+
+    return {
+        "jobs_dispatched": jobs_dispatched,
+        "findings_count": findings_count,
+        "validated_count": validated_count,
+        "rejected_count": rejected_count,
+        "false_positive_rate": round(fp_rate, 1),
+        "total_wall_clock_seconds": total_wall_clock,
+        "total_worker_cost_usd": total_worker_cost,
+        "total_validation_cost_usd": total_validation_cost,
+        "total_cost_usd": round(total_worker_cost + total_validation_cost, 6),
+        "avg_turns_per_job": round(statistics.mean(turn_counts), 1) if turn_counts else 0.0,
+        "total_input_tokens": total_input_tokens,
+        "total_output_tokens": total_output_tokens,
+    }
+
+
+def aggregate_trials(trials: list[dict]) -> dict:
+    """Aggregate metrics across multiple trials of the same model."""
+    n = len(trials)
+    if n == 0:
+        return {"trials": 0}
+
+    def avg(key: str) -> float:
+        return round(sum(t.get(key, 0) for t in trials) / n, 2)
+
+    def std(key: str) -> float:
+        if n < 2:
+            return 0.0
+        values = [t.get(key, 0) for t in trials]
+        return round(statistics.stdev(values), 2)
+
+    return {
+        "trials": n,
+        "avg_findings": avg("findings_count"),
+        "avg_validated": avg("validated_count"),
+        "avg_cost_usd": round(avg("total_cost_usd"), 4),
+        "avg_turns_per_job": avg("avg_turns_per_job"),
+        "avg_wall_clock_seconds": avg("total_wall_clock_seconds"),
+        "std_findings": std("findings_count"),
+        "std_cost_usd": std("total_cost_usd"),
+    }
+
+
+def format_comparison_table(results: dict[str, dict], known_findings: int = 3) -> str:
+    """Format aggregated results as a markdown comparison table."""
+    lines = [
+        "| Model | Trials | Avg Findings | Discovery Rate | FP Rate | Avg Cost | Avg Turns/Job | Avg Time (s) |",
+        "|-------|--------|-------------|----------------|---------|----------|---------------|--------------|",
+    ]
+    for model, agg in sorted(results.items(), key=lambda x: x[1].get("avg_validated", 0), reverse=True):
+        if known_findings > 0:
+            rate = f"{agg['avg_validated'] / known_findings * 100:.0f}%"
+        else:
+            rate = "N/A"
+        lines.append(
+            f"| {model} | {agg['trials']} | {agg['avg_findings']:.1f} | "
+            f"{rate} | {agg.get('avg_fp_rate', 0.0):.0f}% | ${agg['avg_cost_usd']:.4f} | "
+            f"{agg['avg_turns_per_job']:.1f} | {agg['avg_wall_clock_seconds']:.0f} |"
+        )
+    return "\n".join(lines)

--- a/tests/unit/test_benchmark.py
+++ b/tests/unit/test_benchmark.py
@@ -1,0 +1,239 @@
+"""Tests for harness.benchmark — metric extraction, aggregation, and validation."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from harness.benchmark import (
+    aggregate_trials,
+    extract_run_metrics,
+    format_comparison_table,
+    validate_model_string,
+)
+
+# --- Model string validation ---
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "anthropic/claude-sonnet-4-6",
+        "openai/gpt-5.4",
+        "ollama/granite-code:8b",
+        "ollama/qwen3-coder:32b",
+        "openai/gpt-4o",
+    ],
+)
+def test_validate_model_string_valid(model):
+    assert validate_model_string(model) is True
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "gpt-5.4",  # no provider
+        "anthropic/",  # no model
+        "foo bar/baz",  # space
+        "",  # empty
+        "/model",  # no provider
+        "UPPER/case",  # uppercase provider
+    ],
+)
+def test_validate_model_string_invalid(model):
+    assert validate_model_string(model) is False
+
+
+def test_validate_model_string_too_long():
+    """Model strings over 100 chars are rejected."""
+    long_model = "anthropic/" + "a" * 100
+    assert validate_model_string(long_model) is False
+
+
+# --- Metric extraction ---
+
+
+def _write_audit(tmp_path: Path, entries: list[dict]) -> Path:
+    path = tmp_path / "audit.jsonl"
+    with open(path, "w") as f:
+        for e in entries:
+            f.write(json.dumps(e, sort_keys=True) + "\n")
+    return path
+
+
+def test_extract_run_metrics_full(tmp_path):
+    entries = [
+        {"seq": 1, "ts": "2026-04-26T10:00:00.000Z", "run_id": "r1", "job_id": None,
+         "event_type": "run_start", "actor": "orchestrator",
+         "payload": {"command": "run"}, "prev_hash": "genesis", "this_hash": "a"},
+        {"seq": 2, "ts": "2026-04-26T10:00:01.000Z", "run_id": "r1", "job_id": "j1",
+         "event_type": "job_dispatch", "actor": "orchestrator",
+         "payload": {"job_id": "j1", "file_path": "dgif_lib.c", "image": "img"},
+         "prev_hash": "a", "this_hash": "b"},
+        {"seq": 3, "ts": "2026-04-26T10:01:01.000Z", "run_id": "r1", "job_id": "j1",
+         "event_type": "container_exit", "actor": "orchestrator",
+         "payload": {"job_id": "j1", "exit_code": 0, "stdout_len": 5000,
+                     "wall_clock_seconds": 60.0, "turns_used": 15,
+                     "cost_usd": 0.05, "input_tokens": 10000, "output_tokens": 2000,
+                     "verdict": "found"},
+         "prev_hash": "b", "this_hash": "c"},
+        {"seq": 4, "ts": "2026-04-26T10:01:05.000Z", "run_id": "r1", "job_id": "j1",
+         "event_type": "llm_call", "actor": "validation_agent",
+         "payload": {"stage": "validation", "model": "openai/gpt-5.4",
+                     "input_tokens": 4000, "output_tokens": 200, "cost_usd": 0.01},
+         "prev_hash": "c", "this_hash": "d"},
+        {"seq": 5, "ts": "2026-04-26T10:01:06.000Z", "run_id": "r1", "job_id": "j1",
+         "event_type": "finding_validated", "actor": "validation_agent",
+         "payload": {"finding_job_id": "j1", "verdict": "VALIDATE",
+                     "asan_real": True, "repro_plausible": True, "security_meaningful": True},
+         "prev_hash": "d", "this_hash": "e"},
+    ]
+    metrics = extract_run_metrics(_write_audit(tmp_path, entries))
+    assert metrics["jobs_dispatched"] == 1
+    assert metrics["findings_count"] == 1
+    assert metrics["validated_count"] == 1
+    assert metrics["rejected_count"] == 0
+    assert metrics["false_positive_rate"] == pytest.approx(0.0)
+    assert metrics["total_wall_clock_seconds"] == pytest.approx(60.0)
+    assert metrics["total_worker_cost_usd"] == pytest.approx(0.05)
+    assert metrics["total_validation_cost_usd"] == pytest.approx(0.01)
+    assert metrics["total_cost_usd"] == pytest.approx(0.06)
+    assert metrics["avg_turns_per_job"] == pytest.approx(15.0)
+    assert metrics["total_input_tokens"] == 10000
+    assert metrics["total_output_tokens"] == 2000
+
+
+def test_extract_run_metrics_no_findings(tmp_path):
+    entries = [
+        {"seq": 1, "ts": "2026-04-26T10:00:00.000Z", "run_id": "r1", "job_id": None,
+         "event_type": "run_start", "actor": "orchestrator",
+         "payload": {"command": "run"}, "prev_hash": "genesis", "this_hash": "a"},
+        {"seq": 2, "ts": "2026-04-26T10:00:01.000Z", "run_id": "r1", "job_id": "j1",
+         "event_type": "job_dispatch", "actor": "orchestrator",
+         "payload": {"job_id": "j1", "file_path": "test.c", "image": "img"},
+         "prev_hash": "a", "this_hash": "b"},
+        {"seq": 3, "ts": "2026-04-26T10:00:30.000Z", "run_id": "r1", "job_id": "j1",
+         "event_type": "container_exit", "actor": "orchestrator",
+         "payload": {"job_id": "j1", "exit_code": 0, "stdout_len": 100,
+                     "wall_clock_seconds": 29.0, "turns_used": 5, "verdict": "not_found"},
+         "prev_hash": "b", "this_hash": "c"},
+    ]
+    metrics = extract_run_metrics(_write_audit(tmp_path, entries))
+    assert metrics["jobs_dispatched"] == 1
+    assert metrics["findings_count"] == 0
+    assert metrics["validated_count"] == 0
+    assert metrics["total_cost_usd"] == pytest.approx(0.0)
+
+
+def test_extract_run_metrics_backward_compat(tmp_path):
+    """Old audit logs without telemetry fields don't crash."""
+    entries = [
+        {"seq": 1, "ts": "2026-04-26T10:00:00.000Z", "run_id": "r1", "job_id": None,
+         "event_type": "run_start", "actor": "orchestrator",
+         "payload": {"command": "run"}, "prev_hash": "genesis", "this_hash": "a"},
+        {"seq": 2, "ts": "2026-04-26T10:00:01.000Z", "run_id": "r1", "job_id": "j1",
+         "event_type": "job_dispatch", "actor": "orchestrator",
+         "payload": {"job_id": "j1", "file_path": "test.c", "image": "img"},
+         "prev_hash": "a", "this_hash": "b"},
+        # Old format: only exit_code and stdout_len, no telemetry
+        {"seq": 3, "ts": "2026-04-26T10:00:30.000Z", "run_id": "r1", "job_id": "j1",
+         "event_type": "container_exit", "actor": "orchestrator",
+         "payload": {"job_id": "j1", "exit_code": 0, "stdout_len": 100},
+         "prev_hash": "b", "this_hash": "c"},
+    ]
+    metrics = extract_run_metrics(_write_audit(tmp_path, entries))
+    assert metrics["jobs_dispatched"] == 1
+    assert metrics["findings_count"] == 0
+    assert metrics["total_wall_clock_seconds"] == pytest.approx(0.0)
+    assert metrics["avg_turns_per_job"] == pytest.approx(0.0)
+
+
+def test_extract_run_metrics_timeout(tmp_path):
+    """Timed-out containers count as dispatched but not as findings."""
+    entries = [
+        {"seq": 1, "ts": "2026-04-26T10:00:00.000Z", "run_id": "r1", "job_id": None,
+         "event_type": "run_start", "actor": "orchestrator",
+         "payload": {"command": "run"}, "prev_hash": "genesis", "this_hash": "a"},
+        {"seq": 2, "ts": "2026-04-26T10:00:01.000Z", "run_id": "r1", "job_id": "j1",
+         "event_type": "job_dispatch", "actor": "orchestrator",
+         "payload": {"job_id": "j1", "file_path": "test.c", "image": "img"},
+         "prev_hash": "a", "this_hash": "b"},
+        {"seq": 3, "ts": "2026-04-26T10:20:01.000Z", "run_id": "r1", "job_id": "j1",
+         "event_type": "container_exit", "actor": "orchestrator",
+         "payload": {"job_id": "j1", "exit_code": -1, "reason": "timeout",
+                     "stdout_len": 0, "wall_clock_seconds": 1200.0},
+         "prev_hash": "b", "this_hash": "c"},
+    ]
+    metrics = extract_run_metrics(_write_audit(tmp_path, entries))
+    assert metrics["jobs_dispatched"] == 1
+    assert metrics["findings_count"] == 0  # timeout != finding
+    assert metrics["total_wall_clock_seconds"] == pytest.approx(1200.0)
+
+
+# --- Aggregation ---
+
+
+def test_aggregate_trials():
+    trials = [
+        {"findings_count": 3, "validated_count": 2, "rejected_count": 1,
+         "total_cost_usd": 0.10, "avg_turns_per_job": 12.0, "total_wall_clock_seconds": 120.0,
+         "false_positive_rate": 33.3},
+        {"findings_count": 2, "validated_count": 2, "rejected_count": 0,
+         "total_cost_usd": 0.08, "avg_turns_per_job": 10.0, "total_wall_clock_seconds": 100.0,
+         "false_positive_rate": 0.0},
+        {"findings_count": 3, "validated_count": 3, "rejected_count": 0,
+         "total_cost_usd": 0.12, "avg_turns_per_job": 14.0, "total_wall_clock_seconds": 140.0,
+         "false_positive_rate": 0.0},
+    ]
+    agg = aggregate_trials(trials)
+    assert agg["trials"] == 3
+    assert agg["avg_findings"] == pytest.approx(2.67, abs=0.01)
+    assert agg["avg_validated"] == pytest.approx(2.33, abs=0.01)
+    assert agg["avg_cost_usd"] == pytest.approx(0.10, abs=0.01)
+    assert agg["avg_turns_per_job"] == pytest.approx(12.0)
+    assert agg["avg_wall_clock_seconds"] == pytest.approx(120.0)
+    assert "std_findings" in agg
+    assert "std_cost_usd" in agg
+
+
+def test_aggregate_single_trial():
+    trials = [{"findings_count": 3, "validated_count": 3, "rejected_count": 0,
+               "total_cost_usd": 0.10, "avg_turns_per_job": 12.0,
+               "total_wall_clock_seconds": 120.0, "false_positive_rate": 0.0}]
+    agg = aggregate_trials(trials)
+    assert agg["trials"] == 1
+    assert agg["std_findings"] == pytest.approx(0.0)
+
+
+def test_aggregate_zero_trials():
+    agg = aggregate_trials([])
+    assert agg["trials"] == 0
+
+
+# --- Table formatting ---
+
+
+def test_format_comparison_table():
+    results = {
+        "openai/gpt-5.4": {"trials": 3, "avg_findings": 8.0, "avg_validated": 6.0,
+                           "avg_cost_usd": 0.11, "avg_turns_per_job": 15.0,
+                           "avg_wall_clock_seconds": 300.0},
+        "openai/gpt-4o": {"trials": 3, "avg_findings": 0.0, "avg_validated": 0.0,
+                          "avg_cost_usd": 0.00, "avg_turns_per_job": 5.0,
+                          "avg_wall_clock_seconds": 120.0},
+    }
+    table = format_comparison_table(results, known_findings=3)
+    assert "gpt-5.4" in table
+    assert "gpt-4o" in table
+    assert "Discovery" in table
+    assert "200%" in table  # 6.0/3 = 200%
+
+
+def test_format_comparison_table_zero_known():
+    results = {"openai/gpt-4o": {"trials": 1, "avg_findings": 2.0, "avg_validated": 1.0,
+                                  "avg_cost_usd": 0.05, "avg_turns_per_job": 10.0,
+                                  "avg_wall_clock_seconds": 60.0}}
+    table = format_comparison_table(results, known_findings=0)
+    assert "N/A" in table

--- a/tests/unit/test_benchmark.py
+++ b/tests/unit/test_benchmark.py
@@ -65,30 +65,83 @@ def _write_audit(tmp_path: Path, entries: list[dict]) -> Path:
 
 def test_extract_run_metrics_full(tmp_path):
     entries = [
-        {"seq": 1, "ts": "2026-04-26T10:00:00.000Z", "run_id": "r1", "job_id": None,
-         "event_type": "run_start", "actor": "orchestrator",
-         "payload": {"command": "run"}, "prev_hash": "genesis", "this_hash": "a"},
-        {"seq": 2, "ts": "2026-04-26T10:00:01.000Z", "run_id": "r1", "job_id": "j1",
-         "event_type": "job_dispatch", "actor": "orchestrator",
-         "payload": {"job_id": "j1", "file_path": "dgif_lib.c", "image": "img"},
-         "prev_hash": "a", "this_hash": "b"},
-        {"seq": 3, "ts": "2026-04-26T10:01:01.000Z", "run_id": "r1", "job_id": "j1",
-         "event_type": "container_exit", "actor": "orchestrator",
-         "payload": {"job_id": "j1", "exit_code": 0, "stdout_len": 5000,
-                     "wall_clock_seconds": 60.0, "turns_used": 15,
-                     "cost_usd": 0.05, "input_tokens": 10000, "output_tokens": 2000,
-                     "verdict": "found"},
-         "prev_hash": "b", "this_hash": "c"},
-        {"seq": 4, "ts": "2026-04-26T10:01:05.000Z", "run_id": "r1", "job_id": "j1",
-         "event_type": "llm_call", "actor": "validation_agent",
-         "payload": {"stage": "validation", "model": "openai/gpt-5.4",
-                     "input_tokens": 4000, "output_tokens": 200, "cost_usd": 0.01},
-         "prev_hash": "c", "this_hash": "d"},
-        {"seq": 5, "ts": "2026-04-26T10:01:06.000Z", "run_id": "r1", "job_id": "j1",
-         "event_type": "finding_validated", "actor": "validation_agent",
-         "payload": {"finding_job_id": "j1", "verdict": "VALIDATE",
-                     "asan_real": True, "repro_plausible": True, "security_meaningful": True},
-         "prev_hash": "d", "this_hash": "e"},
+        {
+            "seq": 1,
+            "ts": "2026-04-26T10:00:00.000Z",
+            "run_id": "r1",
+            "job_id": None,
+            "event_type": "run_start",
+            "actor": "orchestrator",
+            "payload": {"command": "run"},
+            "prev_hash": "genesis",
+            "this_hash": "a",
+        },
+        {
+            "seq": 2,
+            "ts": "2026-04-26T10:00:01.000Z",
+            "run_id": "r1",
+            "job_id": "j1",
+            "event_type": "job_dispatch",
+            "actor": "orchestrator",
+            "payload": {"job_id": "j1", "file_path": "dgif_lib.c", "image": "img"},
+            "prev_hash": "a",
+            "this_hash": "b",
+        },
+        {
+            "seq": 3,
+            "ts": "2026-04-26T10:01:01.000Z",
+            "run_id": "r1",
+            "job_id": "j1",
+            "event_type": "container_exit",
+            "actor": "orchestrator",
+            "payload": {
+                "job_id": "j1",
+                "exit_code": 0,
+                "stdout_len": 5000,
+                "wall_clock_seconds": 60.0,
+                "turns_used": 15,
+                "cost_usd": 0.05,
+                "input_tokens": 10000,
+                "output_tokens": 2000,
+                "verdict": "found",
+            },
+            "prev_hash": "b",
+            "this_hash": "c",
+        },
+        {
+            "seq": 4,
+            "ts": "2026-04-26T10:01:05.000Z",
+            "run_id": "r1",
+            "job_id": "j1",
+            "event_type": "llm_call",
+            "actor": "validation_agent",
+            "payload": {
+                "stage": "validation",
+                "model": "openai/gpt-5.4",
+                "input_tokens": 4000,
+                "output_tokens": 200,
+                "cost_usd": 0.01,
+            },
+            "prev_hash": "c",
+            "this_hash": "d",
+        },
+        {
+            "seq": 5,
+            "ts": "2026-04-26T10:01:06.000Z",
+            "run_id": "r1",
+            "job_id": "j1",
+            "event_type": "finding_validated",
+            "actor": "validation_agent",
+            "payload": {
+                "finding_job_id": "j1",
+                "verdict": "VALIDATE",
+                "asan_real": True,
+                "repro_plausible": True,
+                "security_meaningful": True,
+            },
+            "prev_hash": "d",
+            "this_hash": "e",
+        },
     ]
     metrics = extract_run_metrics(_write_audit(tmp_path, entries))
     assert metrics["jobs_dispatched"] == 1
@@ -107,18 +160,46 @@ def test_extract_run_metrics_full(tmp_path):
 
 def test_extract_run_metrics_no_findings(tmp_path):
     entries = [
-        {"seq": 1, "ts": "2026-04-26T10:00:00.000Z", "run_id": "r1", "job_id": None,
-         "event_type": "run_start", "actor": "orchestrator",
-         "payload": {"command": "run"}, "prev_hash": "genesis", "this_hash": "a"},
-        {"seq": 2, "ts": "2026-04-26T10:00:01.000Z", "run_id": "r1", "job_id": "j1",
-         "event_type": "job_dispatch", "actor": "orchestrator",
-         "payload": {"job_id": "j1", "file_path": "test.c", "image": "img"},
-         "prev_hash": "a", "this_hash": "b"},
-        {"seq": 3, "ts": "2026-04-26T10:00:30.000Z", "run_id": "r1", "job_id": "j1",
-         "event_type": "container_exit", "actor": "orchestrator",
-         "payload": {"job_id": "j1", "exit_code": 0, "stdout_len": 100,
-                     "wall_clock_seconds": 29.0, "turns_used": 5, "verdict": "not_found"},
-         "prev_hash": "b", "this_hash": "c"},
+        {
+            "seq": 1,
+            "ts": "2026-04-26T10:00:00.000Z",
+            "run_id": "r1",
+            "job_id": None,
+            "event_type": "run_start",
+            "actor": "orchestrator",
+            "payload": {"command": "run"},
+            "prev_hash": "genesis",
+            "this_hash": "a",
+        },
+        {
+            "seq": 2,
+            "ts": "2026-04-26T10:00:01.000Z",
+            "run_id": "r1",
+            "job_id": "j1",
+            "event_type": "job_dispatch",
+            "actor": "orchestrator",
+            "payload": {"job_id": "j1", "file_path": "test.c", "image": "img"},
+            "prev_hash": "a",
+            "this_hash": "b",
+        },
+        {
+            "seq": 3,
+            "ts": "2026-04-26T10:00:30.000Z",
+            "run_id": "r1",
+            "job_id": "j1",
+            "event_type": "container_exit",
+            "actor": "orchestrator",
+            "payload": {
+                "job_id": "j1",
+                "exit_code": 0,
+                "stdout_len": 100,
+                "wall_clock_seconds": 29.0,
+                "turns_used": 5,
+                "verdict": "not_found",
+            },
+            "prev_hash": "b",
+            "this_hash": "c",
+        },
     ]
     metrics = extract_run_metrics(_write_audit(tmp_path, entries))
     assert metrics["jobs_dispatched"] == 1
@@ -130,18 +211,40 @@ def test_extract_run_metrics_no_findings(tmp_path):
 def test_extract_run_metrics_backward_compat(tmp_path):
     """Old audit logs without telemetry fields don't crash."""
     entries = [
-        {"seq": 1, "ts": "2026-04-26T10:00:00.000Z", "run_id": "r1", "job_id": None,
-         "event_type": "run_start", "actor": "orchestrator",
-         "payload": {"command": "run"}, "prev_hash": "genesis", "this_hash": "a"},
-        {"seq": 2, "ts": "2026-04-26T10:00:01.000Z", "run_id": "r1", "job_id": "j1",
-         "event_type": "job_dispatch", "actor": "orchestrator",
-         "payload": {"job_id": "j1", "file_path": "test.c", "image": "img"},
-         "prev_hash": "a", "this_hash": "b"},
+        {
+            "seq": 1,
+            "ts": "2026-04-26T10:00:00.000Z",
+            "run_id": "r1",
+            "job_id": None,
+            "event_type": "run_start",
+            "actor": "orchestrator",
+            "payload": {"command": "run"},
+            "prev_hash": "genesis",
+            "this_hash": "a",
+        },
+        {
+            "seq": 2,
+            "ts": "2026-04-26T10:00:01.000Z",
+            "run_id": "r1",
+            "job_id": "j1",
+            "event_type": "job_dispatch",
+            "actor": "orchestrator",
+            "payload": {"job_id": "j1", "file_path": "test.c", "image": "img"},
+            "prev_hash": "a",
+            "this_hash": "b",
+        },
         # Old format: only exit_code and stdout_len, no telemetry
-        {"seq": 3, "ts": "2026-04-26T10:00:30.000Z", "run_id": "r1", "job_id": "j1",
-         "event_type": "container_exit", "actor": "orchestrator",
-         "payload": {"job_id": "j1", "exit_code": 0, "stdout_len": 100},
-         "prev_hash": "b", "this_hash": "c"},
+        {
+            "seq": 3,
+            "ts": "2026-04-26T10:00:30.000Z",
+            "run_id": "r1",
+            "job_id": "j1",
+            "event_type": "container_exit",
+            "actor": "orchestrator",
+            "payload": {"job_id": "j1", "exit_code": 0, "stdout_len": 100},
+            "prev_hash": "b",
+            "this_hash": "c",
+        },
     ]
     metrics = extract_run_metrics(_write_audit(tmp_path, entries))
     assert metrics["jobs_dispatched"] == 1
@@ -153,18 +256,45 @@ def test_extract_run_metrics_backward_compat(tmp_path):
 def test_extract_run_metrics_timeout(tmp_path):
     """Timed-out containers count as dispatched but not as findings."""
     entries = [
-        {"seq": 1, "ts": "2026-04-26T10:00:00.000Z", "run_id": "r1", "job_id": None,
-         "event_type": "run_start", "actor": "orchestrator",
-         "payload": {"command": "run"}, "prev_hash": "genesis", "this_hash": "a"},
-        {"seq": 2, "ts": "2026-04-26T10:00:01.000Z", "run_id": "r1", "job_id": "j1",
-         "event_type": "job_dispatch", "actor": "orchestrator",
-         "payload": {"job_id": "j1", "file_path": "test.c", "image": "img"},
-         "prev_hash": "a", "this_hash": "b"},
-        {"seq": 3, "ts": "2026-04-26T10:20:01.000Z", "run_id": "r1", "job_id": "j1",
-         "event_type": "container_exit", "actor": "orchestrator",
-         "payload": {"job_id": "j1", "exit_code": -1, "reason": "timeout",
-                     "stdout_len": 0, "wall_clock_seconds": 1200.0},
-         "prev_hash": "b", "this_hash": "c"},
+        {
+            "seq": 1,
+            "ts": "2026-04-26T10:00:00.000Z",
+            "run_id": "r1",
+            "job_id": None,
+            "event_type": "run_start",
+            "actor": "orchestrator",
+            "payload": {"command": "run"},
+            "prev_hash": "genesis",
+            "this_hash": "a",
+        },
+        {
+            "seq": 2,
+            "ts": "2026-04-26T10:00:01.000Z",
+            "run_id": "r1",
+            "job_id": "j1",
+            "event_type": "job_dispatch",
+            "actor": "orchestrator",
+            "payload": {"job_id": "j1", "file_path": "test.c", "image": "img"},
+            "prev_hash": "a",
+            "this_hash": "b",
+        },
+        {
+            "seq": 3,
+            "ts": "2026-04-26T10:20:01.000Z",
+            "run_id": "r1",
+            "job_id": "j1",
+            "event_type": "container_exit",
+            "actor": "orchestrator",
+            "payload": {
+                "job_id": "j1",
+                "exit_code": -1,
+                "reason": "timeout",
+                "stdout_len": 0,
+                "wall_clock_seconds": 1200.0,
+            },
+            "prev_hash": "b",
+            "this_hash": "c",
+        },
     ]
     metrics = extract_run_metrics(_write_audit(tmp_path, entries))
     assert metrics["jobs_dispatched"] == 1
@@ -177,15 +307,33 @@ def test_extract_run_metrics_timeout(tmp_path):
 
 def test_aggregate_trials():
     trials = [
-        {"findings_count": 3, "validated_count": 2, "rejected_count": 1,
-         "total_cost_usd": 0.10, "avg_turns_per_job": 12.0, "total_wall_clock_seconds": 120.0,
-         "false_positive_rate": 33.3},
-        {"findings_count": 2, "validated_count": 2, "rejected_count": 0,
-         "total_cost_usd": 0.08, "avg_turns_per_job": 10.0, "total_wall_clock_seconds": 100.0,
-         "false_positive_rate": 0.0},
-        {"findings_count": 3, "validated_count": 3, "rejected_count": 0,
-         "total_cost_usd": 0.12, "avg_turns_per_job": 14.0, "total_wall_clock_seconds": 140.0,
-         "false_positive_rate": 0.0},
+        {
+            "findings_count": 3,
+            "validated_count": 2,
+            "rejected_count": 1,
+            "total_cost_usd": 0.10,
+            "avg_turns_per_job": 12.0,
+            "total_wall_clock_seconds": 120.0,
+            "false_positive_rate": 33.3,
+        },
+        {
+            "findings_count": 2,
+            "validated_count": 2,
+            "rejected_count": 0,
+            "total_cost_usd": 0.08,
+            "avg_turns_per_job": 10.0,
+            "total_wall_clock_seconds": 100.0,
+            "false_positive_rate": 0.0,
+        },
+        {
+            "findings_count": 3,
+            "validated_count": 3,
+            "rejected_count": 0,
+            "total_cost_usd": 0.12,
+            "avg_turns_per_job": 14.0,
+            "total_wall_clock_seconds": 140.0,
+            "false_positive_rate": 0.0,
+        },
     ]
     agg = aggregate_trials(trials)
     assert agg["trials"] == 3
@@ -199,9 +347,17 @@ def test_aggregate_trials():
 
 
 def test_aggregate_single_trial():
-    trials = [{"findings_count": 3, "validated_count": 3, "rejected_count": 0,
-               "total_cost_usd": 0.10, "avg_turns_per_job": 12.0,
-               "total_wall_clock_seconds": 120.0, "false_positive_rate": 0.0}]
+    trials = [
+        {
+            "findings_count": 3,
+            "validated_count": 3,
+            "rejected_count": 0,
+            "total_cost_usd": 0.10,
+            "avg_turns_per_job": 12.0,
+            "total_wall_clock_seconds": 120.0,
+            "false_positive_rate": 0.0,
+        }
+    ]
     agg = aggregate_trials(trials)
     assert agg["trials"] == 1
     assert agg["std_findings"] == pytest.approx(0.0)
@@ -217,12 +373,22 @@ def test_aggregate_zero_trials():
 
 def test_format_comparison_table():
     results = {
-        "openai/gpt-5.4": {"trials": 3, "avg_findings": 8.0, "avg_validated": 6.0,
-                           "avg_cost_usd": 0.11, "avg_turns_per_job": 15.0,
-                           "avg_wall_clock_seconds": 300.0},
-        "openai/gpt-4o": {"trials": 3, "avg_findings": 0.0, "avg_validated": 0.0,
-                          "avg_cost_usd": 0.00, "avg_turns_per_job": 5.0,
-                          "avg_wall_clock_seconds": 120.0},
+        "openai/gpt-5.4": {
+            "trials": 3,
+            "avg_findings": 8.0,
+            "avg_validated": 6.0,
+            "avg_cost_usd": 0.11,
+            "avg_turns_per_job": 15.0,
+            "avg_wall_clock_seconds": 300.0,
+        },
+        "openai/gpt-4o": {
+            "trials": 3,
+            "avg_findings": 0.0,
+            "avg_validated": 0.0,
+            "avg_cost_usd": 0.00,
+            "avg_turns_per_job": 5.0,
+            "avg_wall_clock_seconds": 120.0,
+        },
     }
     table = format_comparison_table(results, known_findings=3)
     assert "gpt-5.4" in table
@@ -232,8 +398,15 @@ def test_format_comparison_table():
 
 
 def test_format_comparison_table_zero_known():
-    results = {"openai/gpt-4o": {"trials": 1, "avg_findings": 2.0, "avg_validated": 1.0,
-                                  "avg_cost_usd": 0.05, "avg_turns_per_job": 10.0,
-                                  "avg_wall_clock_seconds": 60.0}}
+    results = {
+        "openai/gpt-4o": {
+            "trials": 1,
+            "avg_findings": 2.0,
+            "avg_validated": 1.0,
+            "avg_cost_usd": 0.05,
+            "avg_turns_per_job": 10.0,
+            "avg_wall_clock_seconds": 60.0,
+        }
+    }
     table = format_comparison_table(results, known_findings=0)
     assert "N/A" in table


### PR DESCRIPTION
## Summary
- Create `harness/benchmark.py` with `validate_model_string`, `extract_run_metrics`, `aggregate_trials`, and `format_comparison_table` functions
- Create comprehensive test suite (`tests/unit/test_benchmark.py`) with 21 tests covering model validation, metric extraction from audit JSONL, multi-trial aggregation, comparison table formatting, backward compatibility, and timeout handling
- Module has no dependencies on other tasks -- it only reads audit JSONL files

Closes #30

## Test plan
- [x] All 21 unit tests pass (`uv run pytest tests/unit/test_benchmark.py -v`)
- [x] Lint clean (`uv run ruff check harness/benchmark.py tests/unit/test_benchmark.py`)
- [x] Parametrized model validation: 5 valid, 6 invalid, plus length boundary
- [x] Full audit log extraction verifies all 12 metric fields
- [x] Edge cases: no findings, backward compat (old format), timeout containers
- [x] Aggregation: 3-trial avg/std, single trial (std=0), empty list
- [x] Table formatting: multi-model sort, zero known_findings (N/A, no division error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)