### PR TITLE
feat: dispatcher instrumentation for benchmarking

### DIFF
--- a/harness/cli.py
+++ b/harness/cli.py
@@ -339,7 +339,7 @@ def run(config_path: str, bin_dir: str | None):
         click.echo("Stage 3: Dispatching workers (compiling per container)...")
     from harness.dispatcher import dispatch_run
 
-    results = asyncio.run(dispatch_run(run_id, cfg, audit, repo_path=repo_path, bin_path=bin_dir))
+    results = asyncio.run(dispatch_run(run_id, cfg, audit, repo_path=repo_path, bin_path=bin_dir, run_dir=str(run_dir)))
     click.echo(f"  Completed {len(results)} containers")
 
     # Step 5: Parse and validate

--- a/harness/dispatcher.py
+++ b/harness/dispatcher.py
@@ -3,14 +3,54 @@
 from __future__ import annotations
 
 import asyncio
+import json as _json
 import logging
 import os
+import time
 from datetime import datetime, timezone
 
 from harness.audit import AuditLog
 from harness.queue import dequeue_job, get_run_spend, update_job_status
 
 logger = logging.getLogger(__name__)
+
+
+def _save_stderr(run_dir: str | None, job_id: str, stderr_bytes: bytes) -> None:
+    """Save worker stderr to file for trace analysis. Non-fatal on failure."""
+    if not run_dir:
+        logger.warning("run_dir is None — stderr persistence disabled for job %s", job_id)
+        return
+    try:
+        from pathlib import Path
+
+        path = Path(run_dir) / f"{job_id}.stderr.log"
+        # Sync write is fine: ~0.1ms for 100KB, negligible vs. container runtime (30-1200s).
+        path.write_bytes(stderr_bytes)
+    except OSError as e:
+        logger.warning("Failed to save stderr for job %s: %s", job_id, e)
+
+
+def _extract_telemetry(stdout: str, job_id: str) -> dict:
+    """Extract agent telemetry from stdout JSON. Returns dict of fields or empty dict on failure."""
+    try:
+        agent_out = _json.loads(stdout)
+        if isinstance(agent_out, dict) and agent_out.get("type") == "result":
+            import re
+
+            inner = agent_out.get("result", "")
+            if isinstance(inner, str):
+                m = re.search(r"\{.*\}", inner, re.DOTALL)
+                if m:
+                    agent_out = _json.loads(m.group(0))
+        if isinstance(agent_out, dict):
+            return {
+                key: agent_out.get(key)
+                for key in ("turns_used", "cost_usd", "input_tokens", "output_tokens", "verdict")
+                if agent_out.get(key) is not None
+            }
+    except (ValueError, TypeError) as e:
+        logger.warning("Failed to extract telemetry from job %s: %s", job_id, e)
+    return {}
 
 
 async def _run_container(
@@ -21,6 +61,7 @@ async def _run_container(
     audit: AuditLog,
     repo_path: str | None = None,
     bin_path: str | None = None,
+    run_dir: str | None = None,
 ) -> tuple[str, str, str, int]:
     """Launch a single worker container. Returns (job_id, stdout, stderr, exit_code)."""
     repo = repo_path or config.repo_url
@@ -97,6 +138,7 @@ async def _run_container(
         started_at=datetime.now(timezone.utc).isoformat(),
     )
 
+    start_time = time.monotonic()
     try:
         proc = await asyncio.create_subprocess_exec(
             *cmd,
@@ -111,6 +153,7 @@ async def _run_container(
             )
             exit_code = proc.returncode or 0
         except asyncio.TimeoutError:
+            wall_clock = round(time.monotonic() - start_time, 2)
             container_name = f"worker-{job_id[:12]}"
             logger.warning("Container for job %s timed out, killing container %s", job_id, container_name)
             # Use docker kill to forcefully stop the container (more reliable than proc.kill)
@@ -135,6 +178,7 @@ async def _run_container(
             except (asyncio.TimeoutError, Exception):
                 pass
             exit_code = -1
+            _save_stderr(run_dir, job_id, stderr_bytes)
             await update_job_status(
                 run_id,
                 job_id,
@@ -151,6 +195,7 @@ async def _run_container(
                     "exit_code": exit_code,
                     "reason": "timeout",
                     "stdout_len": len(stdout_bytes),
+                    "wall_clock_seconds": wall_clock,
                 },
                 job_id=job_id,
             )
@@ -158,6 +203,9 @@ async def _run_container(
 
         stdout = stdout_bytes.decode(errors="replace")
         stderr = stderr_bytes.decode(errors="replace")
+        wall_clock = round(time.monotonic() - start_time, 2)
+        _save_stderr(run_dir, job_id, stderr_bytes)
+        agent_telemetry = _extract_telemetry(stdout, job_id)
 
         status = "done" if exit_code == 0 else "failed"
         await update_job_status(
@@ -176,6 +224,8 @@ async def _run_container(
                 "job_id": job_id,
                 "exit_code": exit_code,
                 "stdout_len": len(stdout),
+                "wall_clock_seconds": wall_clock,
+                **{k: v for k, v in agent_telemetry.items() if v is not None},
             },
             job_id=job_id,
         )
@@ -208,11 +258,15 @@ async def dispatch_run(
     audit: AuditLog,
     repo_path: str | None = None,
     bin_path: str | None = None,
+    run_dir: str | None = None,
 ) -> list[tuple[str, str, str, int]]:
     """Dispatch all queued jobs with concurrency control.
 
     Returns list of (job_id, stdout, stderr, exit_code) tuples.
     """
+    if run_dir is None:
+        logger.warning("run_dir is None — stderr persistence and trace analysis will be disabled")
+
     sem = asyncio.Semaphore(config.max_parallel_workers)
     results: list[tuple[str, str, str, int]] = []
 
@@ -226,6 +280,7 @@ async def dispatch_run(
                 audit,
                 repo_path,
                 bin_path,
+                run_dir,
             )
             results.append(result)
 


### PR DESCRIPTION
## Summary

- Add wall-clock timing (`time.monotonic()`) to `container_exit` audit events on both success and timeout paths
- Extract agent telemetry (turns_used, cost_usd, input_tokens, output_tokens, verdict) from worker stdout JSON into audit payloads
- Save worker stderr to `{run_dir}/{job_id}.stderr.log` for post-hoc trace analysis
- Thread `run_dir` parameter from CLI through `dispatch_run` to `_run_container` (defaults to `None` for backward compatibility)

Closes #30

## Changes

**`harness/dispatcher.py`**
- Added `import time` and `import json as _json`
- Added `_save_stderr()` helper — writes stderr bytes to disk, non-fatal on failure (OSError caught)
- Added `_extract_telemetry()` helper — parses stdout JSON for agent metrics, non-fatal on failure (ValueError/TypeError caught)
- Added `run_dir: str | None = None` parameter to `_run_container` and `dispatch_run`
- `start_time = time.monotonic()` placed before subprocess creation
- `container_exit` audit payloads now include `wall_clock_seconds` and any extracted telemetry fields

**`harness/cli.py`**
- Pass `run_dir=str(run_dir)` to `dispatch_run` call

## Test plan

- [x] All 124 unit tests pass (`uv run pytest tests/ --ignore=tests/integration -v`)
- [x] `ruff check` passes on both modified files
- [ ] Integration: verify `container_exit` events contain `wall_clock_seconds` after a real scan
- [ ] Integration: verify `{job_id}.stderr.log` files appear in run directory
- [ ] Integration: verify telemetry fields appear when worker outputs valid JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)