### PR TITLE
Add mantis CLI entry point

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ build-backend = "hatchling.build"
 packages = ["harness"]
 
 [project.scripts]
+mantis = "harness.cli:cli"
 vuln-harness = "harness.cli:cli"
 
 [tool.uv]


### PR DESCRIPTION
## Summary
- Adds `mantis` as a console script entry point in pyproject.toml
- `vuln-harness` still works (backward compatible)
- `mantis run`, `mantis benchmark`, `mantis trace`, etc.

## Test plan
- [ ] `uv run mantis --help` shows all commands
- [ ] `uv run vuln-harness --help` still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)