### PR TITLE
Rename vuln-harness → mantis in all docs

### DIFF
--- a/03-plan.md
+++ b/03-plan.md
@@ -201,15 +201,15 @@ Postgres via `asyncpg`. Manages `runs`, `jobs`, `findings` tables. Generates the
 Click-based CLI. Entry points:
 
 ```
-vuln-harness run --config harness.yaml        # full pipeline run
-vuln-harness rank --config harness.yaml       # stage 1 only, print ranked files
-vuln-harness review --run-id <uuid>           # list findings awaiting review
-vuln-harness approve --finding-id <uuid> \
+mantis run --config harness.yaml        # full pipeline run
+mantis rank --config harness.yaml       # stage 1 only, print ranked files
+mantis review --run-id <uuid>           # list findings awaiting review
+mantis approve --finding-id <uuid> \
   --reviewer "Name" \
   --cvss 7.5 \
   --approve-disclosure                        # record human sign-off
-vuln-harness audit-verify --run-id <uuid>    # verify hash chain integrity
-vuln-harness cost --run-id <uuid>            # print cost breakdown
+mantis audit-verify --run-id <uuid>    # verify hash chain integrity
+mantis cost --run-id <uuid>            # print cost breakdown
 ```
 
 ---

--- a/04-tasks.md
+++ b/04-tasks.md
@@ -112,13 +112,13 @@ Add a fixture `tests/fixtures/sample_ranking_response.json` with a realistic mod
 **Verify**: `uv run pytest tests/unit/test_ranker.py -v` passes.
 
 ### Task 2.2 — CLI `rank` subcommand
-Implement `vuln-harness rank --config harness.yaml` in `harness/cli.py`.
+Implement `mantis rank --config harness.yaml` in `harness/cli.py`.
 - Creates a run directory under `{run_output_dir}/{run_id}/`
 - Calls `rank_files()`
 - Pretty-prints ranked files table to stdout: rank | score | path | reason
 - Prints total files, excluded files, cost
 
-**Verify**: With a real `harness.yaml` pointing to a real C repo (e.g. sqlite), `vuln-harness rank` prints a sensible ranked list. Top files should be parsers, I/O handlers, not headers or test files.
+**Verify**: With a real `harness.yaml` pointing to a real C repo (e.g. sqlite), `mantis rank` prints a sensible ranked list. Top files should be parsers, I/O handlers, not headers or test files.
 
 ---
 
@@ -171,7 +171,7 @@ Jinja2 template. Variables: `file_path`, `project_name`, `project_description`, 
 ### Task 4.3 — `worker/entrypoint.sh`
 Shell script (bash). Steps exactly as in specification:
 1. `set -euo pipefail`
-2. Print "=== vuln-harness worker starting ===" with timestamp
+2. Print "=== mantis worker starting ===" with timestamp
 3. Render task prompt from Jinja2 template using Python one-liner
 4. `cd /target/src`
 5. `git submodule update --init --recursive 2>/dev/null || true`
@@ -291,7 +291,7 @@ The `run` command:
    c. If validated: call `store_finding()`, generate and write report markdown
 7. Print summary: jobs run, findings found, validated, rejected, total cost
 
-**Verify**: `vuln-harness --help` shows all subcommands. `vuln-harness run --help` shows all options.
+**Verify**: `mantis --help` shows all subcommands. `mantis run --help` shows all options.
 
 ### Task 7.2 — Full local pipeline test
 Run the complete pipeline against a real target. Use sqlite (small, C, OSS-Fuzz corpus):
@@ -313,17 +313,17 @@ postgres_url: postgresql://harness:${POSTGRES_PASSWORD}@localhost:5432/vulnharne
 run_output_dir: ./runs
 EOF
 
-vuln-harness run --config harness.yaml
+mantis run --config harness.yaml
 ```
 
 **Verify**:
 - Run completes without unhandled exceptions
 - `runs/` directory contains `file_rankings.json` and `audit.jsonl`
 - `audit.jsonl` has entries for `run_start`, `job_dispatch`, `container_exit`, `llm_call`
-- `vuln-harness audit-verify --run-id <uuid>` prints "Chain valid"
-- `vuln-harness cost --run-id <uuid>` prints itemized cost under $20
+- `mantis audit-verify --run-id <uuid>` prints "Chain valid"
+- `mantis cost --run-id <uuid>` prints itemized cost under $20
 - At least one finding produced (even if validation rejects it — `audit.jsonl` should show the validation call)
-- `vuln-harness review --run-id <uuid>` shows findings table
+- `mantis review --run-id <uuid>` shows findings table
 
 ---
 
@@ -350,7 +350,7 @@ Verify spend limit actually stops dispatch:
 
 **Verify**: `audit.jsonl` contains a `spend_limit_reached` event. No more than 2 containers were dispatched.
 
-### Task 8.3 — `vuln-harness audit-verify` correctness test
+### Task 8.3 — `mantis audit-verify` correctness test
 - Run a pipeline, collect `audit.jsonl`
 - Manually corrupt one character in the middle of the file
 - Run `audit-verify`

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Built for enterprise use in regulated industries. Satisfies NIST frameworks and 
 
 ```bash
 # 1. Clone and install dependencies
-git clone <repo-url> && cd vuln-harness
+git clone <repo-url> && cd mantis
 uv sync
 
 # 2. Start Redis and Postgres
@@ -42,7 +42,7 @@ export OPENAI_API_KEY=sk-...           # for OpenAI models
 # export VALIDATION_MODEL=openai/gpt-4o
 
 export FINDINGS_ENC_KEY=$(python3 -c "import os,base64; print(base64.b64encode(os.urandom(32)).decode())")
-vuln-harness run --config harness.yaml
+mantis run --config harness.yaml
 ```
 
 ## Architecture overview
@@ -83,13 +83,13 @@ export OPENAI_API_KEY=sk-...
 export WORKER_MODEL=openai/gpt-4o
 export RANKING_MODEL=openai/gpt-4o
 export VALIDATION_MODEL=openai/gpt-4o
-vuln-harness run --config harness.yaml
+mantis run --config harness.yaml
 
 # Switch to Ollama (local)
 export WORKER_MODEL=ollama/llama3
 export RANKING_MODEL=ollama/llama3
 export VALIDATION_MODEL=ollama/llama3
-vuln-harness run --config harness.yaml
+mantis run --config harness.yaml
 ```
 
 The YAML configs default to Anthropic models, but any [litellm-supported provider](https://docs.litellm.ai/docs/providers) works. Any field in `harness/config.py` can be overridden by setting an env var with the matching name.
@@ -109,28 +109,28 @@ The YAML configs default to Anthropic models, but any [litellm-supported provide
 
 ```bash
 # Pre-compile target with ASAN (binaries reused across workers)
-vuln-harness build --config harness.yaml
+mantis build --config harness.yaml
 
 # Full pipeline (auto-builds, then dispatches workers)
-vuln-harness run --config harness.yaml
+mantis run --config harness.yaml
 
 # Use pre-compiled binaries from a previous build
-vuln-harness run --config harness.yaml --bin-dir runs/<run-id>/bin
+mantis run --config harness.yaml --bin-dir runs/<run-id>/bin
 
 # Stage 1 only: rank files by vulnerability likelihood
-vuln-harness rank --config harness.yaml
+mantis rank --config harness.yaml
 
 # List findings awaiting human review
-vuln-harness review --run-id <uuid>
+mantis review --run-id <uuid>
 
 # Record human sign-off on a finding
-vuln-harness approve --finding-id <uuid> --reviewer "Name" --cvss 7.5 --approve-disclosure
+mantis approve --finding-id <uuid> --reviewer "Name" --cvss 7.5 --approve-disclosure
 
 # Verify audit log hash chain integrity
-vuln-harness audit-verify --run-id <uuid>
+mantis audit-verify --run-id <uuid>
 
 # Print cost breakdown for a run
-vuln-harness cost --run-id <uuid>
+mantis cost --run-id <uuid>
 ```
 
 ## Development

--- a/architecture.md
+++ b/architecture.md
@@ -140,7 +140,7 @@ All LLM calls route through litellm, making the system provider-agnostic. The de
 **Design decisions**:
 - **Build once, scan many**: Compilation takes minutes for large projects (e.g. FFmpeg). Building once and mounting the result read-only into every worker container eliminates this per-container overhead.
 - **Build-system auto-detection**: The builder tries configure, autotools (autoreconf), cmake, and Makefile in order. `configure_flags` in config allows project-specific build options (e.g. FFmpeg's `--extra-cflags`).
-- **Fallback compilation**: If no `--bin-dir` is supplied to `vuln-harness run`, the pipeline auto-builds before dispatch. If pre-compiled binaries are mounted into the worker, the entrypoint skips compilation entirely.
+- **Fallback compilation**: If no `--bin-dir` is supplied to `mantis run`, the pipeline auto-builds before dispatch. If pre-compiled binaries are mounted into the worker, the entrypoint skips compilation entirely.
 
 ---
 
@@ -356,13 +356,13 @@ Spend is tracked at two levels:
 
 The worker agent loop tracks cost internally via litellm's `response_cost` metadata on each completion call. Token counts (`input_tokens`, `output_tokens`) and cost are included in every `llm_call` audit entry from both the orchestrator (ranking, validation) and workers.
 
-All LLM calls are also logged to the audit trail with model name, token counts, and cost, providing a complete cost breakdown per stage. The CLI command `vuln-harness cost --run-id <uuid>` parses the audit log and prints a per-stage cost summary.
+All LLM calls are also logged to the audit trail with model name, token counts, and cost, providing a complete cost breakdown per stage. The CLI command `mantis cost --run-id <uuid>` parses the audit log and prints a per-stage cost summary.
 
 ---
 
 ## Audit and encryption
 
-**Audit log** (`harness/audit.py`): Append-only JSONL, one entry per action. Each entry includes a SHA-3 hash of its contents and the hash of the previous entry, forming a tamper-evident chain. Writes are synchronous with file locking (`fcntl.LOCK_EX`). If a write fails, the run fails (P3). Chain integrity is verifiable via `vuln-harness audit-verify`.
+**Audit log** (`harness/audit.py`): Append-only JSONL, one entry per action. Each entry includes a SHA-3 hash of its contents and the hash of the previous entry, forming a tamper-evident chain. Writes are synchronous with file locking (`fcntl.LOCK_EX`). If a write fails, the run fails (P3). Chain integrity is verifiable via `mantis audit-verify`.
 
 **Findings encryption** (`harness/crypto.py`): Reproduction steps, candidate patches, and ASAN output are encrypted with AES-256-GCM before storage in Postgres. The encryption key is loaded from the `FINDINGS_ENC_KEY` environment variable (base64-encoded, 32-byte key). Exploit code is never stored in plaintext (P8).
 

--- a/poc/giflib-5.1.4/README.md
+++ b/poc/giflib-5.1.4/README.md
@@ -7,7 +7,7 @@ Three vulnerabilities discovered by Mantis in giflib 5.1.4, each with a standalo
 Build giflib 5.1.4 with AddressSanitizer:
 
 ```bash
-vuln-harness build --config harness-giflib.yaml
+mantis build --config harness-giflib.yaml
 # Or manually:
 cd runs/giflib514-src
 export CC=clang CFLAGS="-fsanitize=address -g -O1 -fno-omit-frame-pointer"


### PR DESCRIPTION
## Summary
- Updates all CLI references in docs from `vuln-harness` to `mantis`
- 5 files, 31 line changes (pure find-replace)
- `vuln-harness` still works as an alias (both entry points in pyproject.toml)

## Test plan
- [ ] Grep confirms no stale `vuln-harness` CLI references in docs
- [ ] `mantis --help` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)