### PR TITLE
feat: configurable prompt templates per run

### DIFF
--- a/harness/config.py
+++ b/harness/config.py
@@ -77,6 +77,7 @@ class Config(BaseSettings):
     max_day_spend_usd: float = 500.0
 
     # Container
+    worker_prompts_dir: str = ""  # Override prompt templates (mounted into container at /prompts)
     worker_image: str = "vuln-harness-worker:latest"
     container_timeout_seconds: int = 1800
     worker_memory_gb: int = 4

--- a/harness/dispatcher.py
+++ b/harness/dispatcher.py
@@ -88,6 +88,10 @@ async def _run_container(
     if bin_path:
         bin_real = os.path.realpath(bin_path)
         cmd.extend(["-v", f"{bin_real}:/target/bin:ro"])
+    # Mount custom prompts if configured (overrides baked-in /prompts/)
+    if config.worker_prompts_dir:
+        prompts_real = os.path.realpath(config.worker_prompts_dir)
+        cmd.extend(["-v", f"{prompts_real}:/prompts:ro"])
     # Pass through provider API keys from environment (litellm reads them automatically)
     for key_name in ("ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GOOGLE_API_KEY"):
         key_val = os.environ.get(key_name)


### PR DESCRIPTION
## Summary
- Adds `worker_prompts_dir` config field (YAML or `WORKER_PROMPTS_DIR` env var)
- When set, the directory is mounted into the container at `/prompts:ro`, overriding baked-in templates
- Enables per-model prompt engineering without rebuilding the Docker image

## Usage
```yaml
# harness-giflib-gpt55.yaml
worker_prompts_dir: ./prompts/gpt55
worker_model: openai/gpt-5.5
```

Or via env var:
```bash
WORKER_PROMPTS_DIR=./prompts/gpt55 mantis run --config harness-giflib.yaml
```

## Motivation
GPT-5.5 uses only 2-6 turns (out of 30) and never crafts inputs — it reads code and gives up.
GPT-5.4 uses 15+ turns and finds 8 bugs on the same target. The prompt needs to be more
directive for models that are overly cautious about crafting exploit inputs.

## Test plan
- [ ] `make test` passes (no existing tests break)
- [ ] Empty `worker_prompts_dir` (default) uses baked-in prompts (backward compat)
- [ ] Set `worker_prompts_dir` to a dir with modified templates, verify container uses them

Closes #30 (partial — enables prompt engineering for benchmark)

🤖 Generated with [Claude Code](https://claude.com/claude-code)