### PR TITLE
feat: auto-configure Ollama for local model support

### DIFF
--- a/harness/dispatcher.py
+++ b/harness/dispatcher.py
@@ -92,6 +92,10 @@ async def _run_container(
     if config.worker_prompts_dir:
         prompts_real = os.path.realpath(config.worker_prompts_dir)
         cmd.extend(["-v", f"{prompts_real}:/prompts:ro"])
+    # For Ollama models, set API base to host.docker.internal so container can reach host Ollama
+    if config.worker_model.startswith("ollama/"):
+        ollama_base = os.environ.get("OLLAMA_API_BASE", "http://host.docker.internal:11434")
+        cmd.extend(["-e", f"OLLAMA_API_BASE={ollama_base}"])
     # Pass through provider API keys from environment (litellm reads them automatically)
     for key_name in ("ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GOOGLE_API_KEY"):
         key_val = os.environ.get(key_name)


### PR DESCRIPTION
## Summary
- Auto-sets `OLLAMA_API_BASE=http://host.docker.internal:11434` when worker model is `ollama/*`
- Enables running local models (qwen3.6, granite, etc.) without manual configuration
- Docker Desktop for Mac provides `host.docker.internal` natively (no `--add-host` needed)

## Test result
Qwen 3.6 27B connects and responds from inside the container. However, it doesn't engage with the tool-use loop — 0 turns, 0 findings on giflib. This is a model capability gap, not a Mantis issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)